### PR TITLE
Upgrade the package karma-jasmine

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "karma-cli": "~1.0.1",
     "karma-coverage-istanbul-reporter": "~2.1.0",
     "karma-html-detailed-reporter": "^1.1.38",
-    "karma-jasmine": "~1.1.2",
+    "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.4.2",
     "karma-spec-reporter": "^0.0.32",
     "ng-packagr": "^5.7.0",

--- a/projects/knora/action/src/lib/jdn-datepicker/jdn-datepicker.directive.spec.ts
+++ b/projects/knora/action/src/lib/jdn-datepicker/jdn-datepicker.directive.spec.ts
@@ -30,7 +30,7 @@ describe('JdnDatepickerDirective', () => {
         jdnDatepicker = fixture.debugElement.query(By.css('jdnDatepicker'));
     });
 
-    it('should create an instance', () => {
+    xit('should create an instance', () => {
         const directive = new JdnDatepickerDirective(adapter);
         expect(directive).toBeTruthy();
     });

--- a/projects/knora/action/src/lib/jdn-datepicker/jdn-datepicker.directive.spec.ts
+++ b/projects/knora/action/src/lib/jdn-datepicker/jdn-datepicker.directive.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { DebugElement } from '@angular/core';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { DebugElement, Component, OnInit, ViewChild, Inject } from '@angular/core';
+import { FormsModule, ReactiveFormsModule, FormBuilder } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { DateAdapter, MAT_DATE_LOCALE, MatNativeDateModule } from '@angular/material/core';
 import { MatDatepickerModule } from '@angular/material/datepicker';
@@ -12,27 +12,61 @@ import { JDNConvertibleCalendar } from 'jdnconvertiblecalendar';
 import { DateValueComponent } from '@knora/search';
 
 describe('JdnDatepickerDirective', () => {
-    let component: DateValueComponent;
-    let fixture: ComponentFixture<DateValueComponent>;
     let jdnDatepicker: DebugElement;
     let adapter: DateAdapter<JDNConvertibleCalendar>;
 
+    let testHostComponent: TestHostComponent;
+    let testHostFixture: ComponentFixture<TestHostComponent>;
+
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [MatDatepickerModule, MatFormFieldModule, MatNativeDateModule, FormsModule, ReactiveFormsModule],
-            declarations: [DateValueComponent, JdnDatepickerDirective],
+            imports: [
+                MatDatepickerModule,
+                MatFormFieldModule,
+                MatNativeDateModule,
+                FormsModule,
+                ReactiveFormsModule
+            ],
+            declarations: [
+                DateValueComponent,
+                TestHostComponent,
+                JdnDatepickerDirective
+            ],
             providers: [
-                { provide: DateAdapter, useClass: JDNConvertibleCalendarDateAdapter, deps: [MAT_DATE_LOCALE] }
+                { provide: DateAdapter, useClass: JDNConvertibleCalendarDateAdapter, deps: [MAT_DATE_LOCALE] },
+                FormBuilder
             ]
         });
-        fixture = TestBed.createComponent(DateValueComponent);
-        component = fixture.componentInstance;
-        jdnDatepicker = fixture.debugElement.query(By.css('jdnDatepicker'));
+        testHostFixture = TestBed.createComponent(TestHostComponent);
+        testHostComponent = testHostFixture.componentInstance;
+        jdnDatepicker = testHostFixture.debugElement.query(By.css('jdnDatepicker'));
     });
 
-    xit('should create an instance', () => {
+    it('should create an instance', () => {
         const directive = new JdnDatepickerDirective(adapter);
         expect(directive).toBeTruthy();
     });
 
 });
+
+/**
+ * Test host component to simulate parent component.
+ */
+@Component({
+    selector: `host-component`,
+    template: `
+        <date-value #dateVal [formGroup]="form"></date-value>`
+})
+class TestHostComponent implements OnInit {
+
+    form;
+
+    @ViewChild('dateVal', { static: false }) dateValue: DateValueComponent;
+
+    constructor(@Inject(FormBuilder) private fb: FormBuilder) {
+    }
+
+    ngOnInit() {
+        this.form = this.fb.group({});
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3783,13 +3783,13 @@ istanbul@0.4.5:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
+jasmine-core@^3.3, jasmine-core@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.5.0.tgz#132c23e645af96d85c8bca13c8758b18429fc1e4"
+
 jasmine-core@~2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.8.0.tgz#bcc979ae1f9fd05701e45e52e65d3a5d63f1a24e"
-
-jasmine-core@~3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.5.0.tgz#132c23e645af96d85c8bca13c8758b18429fc1e4"
 
 jasmine-marbles@^0.6.0:
   version "0.6.0"
@@ -3975,9 +3975,12 @@ karma-jasmine-html-reporter@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-1.4.2.tgz#16d100fd701271192d27fd28ddc90b710ad36fff"
 
-karma-jasmine@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/karma-jasmine/-/karma-jasmine-1.1.2.tgz#394f2b25ffb4a644b9ada6f22d443e2fd08886c3"
+karma-jasmine@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/karma-jasmine/-/karma-jasmine-2.0.1.tgz#26e3e31f2faf272dd80ebb0e1898914cc3a19763"
+  integrity sha512-iuC0hmr9b+SNn1DaUD2QEYtUxkS1J+bSJSn7ejdEexs7P8EYvA1CWkEdrDQ+8jVH3AgWlCNwjYsT1chjcNW9lA==
+  dependencies:
+    jasmine-core "^3.3"
 
 karma-source-map-support@1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Update karma-jasmine from v1.1.2 to v2.0.1

resolves #363 

Fix the error _TypeError: Cannot read property 'removeControl' of undefined_ in jdnDatepickerComponent by creating an host component to mock dateValueComponent