### PR TITLE
Simple resource viewer with knora-api-js-lib

### DIFF
--- a/projects/knora/action/src/lib/pipes/truncate.pipe.ts
+++ b/projects/knora/action/src/lib/pipes/truncate.pipe.ts
@@ -5,11 +5,11 @@ import { Pipe, PipeTransform } from '@angular/core';
  *
  * In markup:
  *
- * {{ str | kuiTruncate:[24] }}
+ * {{ str | kuiTruncate:['24'] }}
  *
  * or
  *
- * {{ str | kuiTruncate:[24, '...'] }}
+ * {{ str | kuiTruncate:['24', '...'] }}
  *
  *
  * The first parameter defines the length where to truncate the string.

--- a/projects/knora/viewer/src/lib/assets/style/viewer.scss
+++ b/projects/knora/viewer/src/lib/assets/style/viewer.scss
@@ -40,36 +40,3 @@ a {
   position: relative;
   overflow: hidden;
 }
-
-// .lv-read-more {
-//   position: absolute;
-//   bottom: 0;
-//   left: 0;
-//   width: 100%;
-//   text-align: center;
-//   margin: 0;
-//   padding: 30px 0;
-//   border-radius: 3px;
-// }
-
-/*
- * shading the html text
- */
-
-/* .lv-html-text .lv-read-more {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  text-align: center;
-  margin: 0; padding: 30px 0;
-  border-radius: 3px;
-  border-color: rgb(255, 255, 255);
-
-  background-image: -webkit-gradient(
-  linear,
-  left top,
-  left bottom,
-  color-stop(0, rgba(255, 255, 255, 0)),
-  color-stop(1, rgba(200, 200, 200, 1)));
-} */

--- a/projects/knora/viewer/src/lib/assets/style/viewer.scss
+++ b/projects/knora/viewer/src/lib/assets/style/viewer.scss
@@ -31,22 +31,26 @@ a {
   }
 }
 
+.lv-prop-label {
+  color: rgba(0, 0, 0, 0.54);
+}
+
 .lv-html-text {
-  max-height: 60px;
+  //   max-height: 60px;
   position: relative;
   overflow: hidden;
 }
 
-.lv-read-more {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  text-align: center;
-  margin: 0;
-  padding: 30px 0;
-  border-radius: 3px;
-}
+// .lv-read-more {
+//   position: absolute;
+//   bottom: 0;
+//   left: 0;
+//   width: 100%;
+//   text-align: center;
+//   margin: 0;
+//   padding: 30px 0;
+//   border-radius: 3px;
+// }
 
 /*
  * shading the html text

--- a/projects/knora/viewer/src/lib/property/boolean-value/boolean-value.component.html
+++ b/projects/knora/viewer/src/lib/property/boolean-value/boolean-value.component.html
@@ -1,1 +1,1 @@
-<mat-checkbox [checked]="valueObject.bool" disabled="true"></mat-checkbox>
+<mat-checkbox [checked]="valueObject.bool" readonly="true"></mat-checkbox>

--- a/projects/knora/viewer/src/lib/property/boolean-value/boolean-value.component.ts
+++ b/projects/knora/viewer/src/lib/property/boolean-value/boolean-value.component.ts
@@ -1,24 +1,24 @@
 import { Component, Input } from '@angular/core';
-import { ReadBooleanValue } from '@knora/core';
+import { ReadBooleanValue } from '@knora/api';
 
 @Component({
-  selector: 'kui-boolean-value',
-  templateUrl: './boolean-value.component.html',
-  styleUrls: ['./boolean-value.component.scss']
+    selector: 'kui-boolean-value',
+    templateUrl: './boolean-value.component.html',
+    styleUrls: ['./boolean-value.component.scss']
 })
 export class BooleanValueComponent {
 
-  @Input()
-  set valueObject(value: ReadBooleanValue) {
-      this._booleanValueObj = value;
-  }
+    @Input()
+    set valueObject(value: ReadBooleanValue) {
+        this._booleanValueObj = value;
+    }
 
-  get valueObject() {
-      return this._booleanValueObj;
-  }
+    get valueObject() {
+        return this._booleanValueObj;
+    }
 
-  private _booleanValueObj: ReadBooleanValue;
+    private _booleanValueObj: ReadBooleanValue;
 
-  constructor() { }
+    constructor() { }
 
 }

--- a/projects/knora/viewer/src/lib/property/color-value/color-value.component.html
+++ b/projects/knora/viewer/src/lib/property/color-value/color-value.component.html
@@ -1,1 +1,1 @@
-<span [style.background-color]="valueObject.colorHex">{{valueObject.colorHex}}</span>
+<span [style.background-color]="valueObject.color">{{valueObject.color}}</span>

--- a/projects/knora/viewer/src/lib/property/color-value/color-value.component.ts
+++ b/projects/knora/viewer/src/lib/property/color-value/color-value.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { ReadColorValue } from '@knora/core';
+import { ReadColorValue } from '@knora/api';
 
 @Component({
     selector: 'kui-color-value',

--- a/projects/knora/viewer/src/lib/property/date-value/date-value.component.ts
+++ b/projects/knora/viewer/src/lib/property/date-value/date-value.component.ts
@@ -2,94 +2,94 @@ import { Component, Input } from '@angular/core';
 import { DateRangeSalsah, DateSalsah, Precision, ReadDateValue } from '@knora/core';
 
 @Component({
-  selector: 'kui-date-value',
-  templateUrl: './date-value.component.html',
-  styleUrls: ['./date-value.component.scss']
+    selector: 'kui-date-value',
+    templateUrl: './date-value.component.html',
+    styleUrls: ['./date-value.component.scss']
 })
 export class DateValueComponent {
 
-  @Input()
-  set calendar(value: boolean) {
-    this._calendar = value;
-  }
-
-  get calendar() {
-    return this._calendar;
-  }
-
-  @Input()
-  set era(value: boolean) {
-    this._era = value;
-  }
-
-  get era() {
-    return this._era;
-  }
-
-  @Input()
-  set valueObject(value: ReadDateValue) {
-    this._dateValueObj = value;
-
-    const dateOrRange: DateSalsah | DateRangeSalsah = this.valueObject.getDateSalsah();
-    if (dateOrRange instanceof DateRangeSalsah) {
-      // period (start and end dates)
-      this.period = true;
-      this.dates = [this.getJSDate(dateOrRange.start), this.getJSDate(dateOrRange.end)];
-    } else {
-      // single date
-      this.period = false;
-      this.dates = [this.getJSDate(dateOrRange)];
+    @Input()
+    set calendar(value: boolean) {
+        this._calendar = value;
     }
 
-  }
-
-  get valueObject() {
-    return this._dateValueObj;
-  }
-
-  dates: DateFormatter[];
-  period: boolean;
-  private _calendar: boolean;
-  private _era: boolean;
-  private _dateValueObj: ReadDateValue;
-
-  constructor() { }
-
-  /**
-   * Converts a `DateSalsah` to a JS Date, providing necessary formatting information.
-   * JULIAN and GREGORIAN calendar are the only available for the moment.
-   *
-   * @param date the date to be converted.
-   * @return DateFormatter.
-   */
-  getJSDate(date: DateSalsah): DateFormatter {
-
-    if (date.precision === Precision.yearPrecision) {
-      return {
-        format: 'yyyy',
-        date: new Date(date.year.toString()),
-        era: date.era,
-        calendar: date.calendar
-      };
-    } else if (date.precision === Precision.monthPrecision) {
-      return {
-        format: 'MMMM ' + 'yyyy',
-        date: new Date(date.year, date.month - 1, 1), // 0 base month
-        era: date.era,
-        calendar: date.calendar
-      };
-    } else if (date.precision === Precision.dayPrecision) {
-      return {
-        format: 'longDate',
-        date: new Date(date.year, date.month - 1, date.day),  // 0 base month
-        era: date.era,
-        calendar: date.calendar
-      };
-    } else {
-      console.error('Error: incorrect precision for date');
+    get calendar() {
+        return this._calendar;
     }
 
-  }
+    @Input()
+    set era(value: boolean) {
+        this._era = value;
+    }
+
+    get era() {
+        return this._era;
+    }
+
+    @Input()
+    set valueObject(value: ReadDateValue) {
+        this._dateValueObj = value;
+
+        const dateOrRange: DateSalsah | DateRangeSalsah = this.valueObject.getDateSalsah();
+        if (dateOrRange instanceof DateRangeSalsah) {
+            // period (start and end dates)
+            this.period = true;
+            this.dates = [this.getJSDate(dateOrRange.start), this.getJSDate(dateOrRange.end)];
+        } else {
+            // single date
+            this.period = false;
+            this.dates = [this.getJSDate(dateOrRange)];
+        }
+
+    }
+
+    get valueObject() {
+        return this._dateValueObj;
+    }
+
+    dates: DateFormatter[];
+    period: boolean;
+    private _calendar: boolean;
+    private _era: boolean;
+    private _dateValueObj: ReadDateValue;
+
+    constructor() { }
+
+    /**
+     * Converts a `DateSalsah` to a JS Date, providing necessary formatting information.
+     * JULIAN and GREGORIAN calendar are the only available for the moment.
+     *
+     * @param date the date to be converted.
+     * @return DateFormatter.
+     */
+    getJSDate(date: DateSalsah): DateFormatter {
+
+        if (date.precision === Precision.yearPrecision) {
+            return {
+                format: 'yyyy',
+                date: new Date(date.year.toString()),
+                era: date.era,
+                calendar: date.calendar
+            };
+        } else if (date.precision === Precision.monthPrecision) {
+            return {
+                format: 'MMMM ' + 'yyyy',
+                date: new Date(date.year, date.month - 1, 1), // 0 base month
+                era: date.era,
+                calendar: date.calendar
+            };
+        } else if (date.precision === Precision.dayPrecision) {
+            return {
+                format: 'longDate',
+                date: new Date(date.year, date.month - 1, date.day),  // 0 base month
+                era: date.era,
+                calendar: date.calendar
+            };
+        } else {
+            console.error('Error: incorrect precision for date');
+        }
+
+    }
 
 }
 
@@ -97,8 +97,8 @@ export class DateValueComponent {
  * Date structure for the template
  */
 export interface DateFormatter {
-  format: string;
-  date: Date;
-  era: string;
-  calendar: string;
+    format: string;
+    date: Date;
+    era: string;
+    calendar: string;
 }

--- a/projects/knora/viewer/src/lib/property/decimal-value/decimal-value.component.ts
+++ b/projects/knora/viewer/src/lib/property/decimal-value/decimal-value.component.ts
@@ -1,24 +1,24 @@
 import { Component, Input } from '@angular/core';
-import { ReadDecimalValue } from '@knora/core';
+import { ReadDecimalValue } from '@knora/api';
 
 @Component({
-  selector: 'kui-decimal-value',
-  templateUrl: './decimal-value.component.html',
-  styleUrls: ['./decimal-value.component.scss']
+    selector: 'kui-decimal-value',
+    templateUrl: './decimal-value.component.html',
+    styleUrls: ['./decimal-value.component.scss']
 })
 export class DecimalValueComponent {
 
-  @Input()
-  set valueObject(value: ReadDecimalValue) {
-    this._decimalValueObj = value;
-  }
+    @Input()
+    set valueObject(value: ReadDecimalValue) {
+        this._decimalValueObj = value;
+    }
 
-  get valueObject() {
-    return this._decimalValueObj;
-  }
+    get valueObject() {
+        return this._decimalValueObj;
+    }
 
-  private _decimalValueObj: ReadDecimalValue;
+    private _decimalValueObj: ReadDecimalValue;
 
-  constructor() { }
+    constructor() { }
 
 }

--- a/projects/knora/viewer/src/lib/property/geometry-value/geometry-value.component.html
+++ b/projects/knora/viewer/src/lib/property/geometry-value/geometry-value.component.html
@@ -1,1 +1,1 @@
-<span>{{valueObject.geometryString}}</span>
+<span>{{valueObject.geometry}}</span>

--- a/projects/knora/viewer/src/lib/property/geometry-value/geometry-value.component.ts
+++ b/projects/knora/viewer/src/lib/property/geometry-value/geometry-value.component.ts
@@ -1,24 +1,24 @@
 import { Component, Input } from '@angular/core';
-import { ReadGeomValue } from '@knora/core';
+import { ReadGeomValue } from '@knora/api';
 
 @Component({
-  selector: 'kui-geometry-value',
-  templateUrl: './geometry-value.component.html',
-  styleUrls: ['./geometry-value.component.scss']
+    selector: 'kui-geometry-value',
+    templateUrl: './geometry-value.component.html',
+    styleUrls: ['./geometry-value.component.scss']
 })
 export class GeometryValueComponent {
 
-  @Input()
-  set valueObject(value: ReadGeomValue) {
-    this._geomValueObj = value;
-  }
+    @Input()
+    set valueObject(value: ReadGeomValue) {
+        this._geomValueObj = value;
+    }
 
-  get valueObject() {
-    return this._geomValueObj;
-  }
+    get valueObject() {
+        return this._geomValueObj;
+    }
 
-  private _geomValueObj: ReadGeomValue;
+    private _geomValueObj: ReadGeomValue;
 
-  constructor() { }
+    constructor() { }
 
 }

--- a/projects/knora/viewer/src/lib/property/integer-value/integer-value.component.html
+++ b/projects/knora/viewer/src/lib/property/integer-value/integer-value.component.html
@@ -1,1 +1,1 @@
-<span>{{valueObject.integer}}</span>
+<span>{{valueObject.int}}</span>

--- a/projects/knora/viewer/src/lib/property/integer-value/integer-value.component.ts
+++ b/projects/knora/viewer/src/lib/property/integer-value/integer-value.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { ReadIntegerValue } from '@knora/core';
+import { ReadIntValue } from '@knora/api';
 
 @Component({
     selector: 'kui-integer-value',
@@ -9,7 +9,7 @@ import { ReadIntegerValue } from '@knora/core';
 export class IntegerValueComponent {
 
     @Input()
-    set valueObject(value: ReadIntegerValue) {
+    set valueObject(value: ReadIntValue) {
         this._integerValueObj = value;
     }
 
@@ -17,7 +17,7 @@ export class IntegerValueComponent {
         return this._integerValueObj;
     }
 
-    private _integerValueObj: ReadIntegerValue;
+    private _integerValueObj: ReadIntValue;
 
     constructor() {
     }

--- a/projects/knora/viewer/src/lib/property/interval-value/interval-value.component.html
+++ b/projects/knora/viewer/src/lib/property/interval-value/interval-value.component.html
@@ -1,1 +1,1 @@
-<span>{{valueObject.intervalStart}} - {{valueObject.intervalEnd}}</span>
+<span>{{valueObject.start}} - {{valueObject.end}}</span>

--- a/projects/knora/viewer/src/lib/property/interval-value/interval-value.component.ts
+++ b/projects/knora/viewer/src/lib/property/interval-value/interval-value.component.ts
@@ -1,24 +1,24 @@
 import { Component, Input } from '@angular/core';
-import { ReadIntervalValue } from '@knora/core';
+import { ReadIntervalValue } from '@knora/api';
 
 @Component({
-  selector: 'kui-interval-value',
-  templateUrl: './interval-value.component.html',
-  styleUrls: ['./interval-value.component.scss']
+    selector: 'kui-interval-value',
+    templateUrl: './interval-value.component.html',
+    styleUrls: ['./interval-value.component.scss']
 })
 export class IntervalValueComponent {
 
-  @Input()
-  set valueObject(value: ReadIntervalValue) {
-    this._intervalValueObj = value;
-  }
+    @Input()
+    set valueObject(value: ReadIntervalValue) {
+        this._intervalValueObj = value;
+    }
 
-  get valueObject() {
-    return this._intervalValueObj;
-  }
+    get valueObject() {
+        return this._intervalValueObj;
+    }
 
-  private _intervalValueObj: ReadIntervalValue;
+    private _intervalValueObj: ReadIntervalValue;
 
-  constructor() { }
+    constructor() { }
 
 }

--- a/projects/knora/viewer/src/lib/property/text-value/text-value-as-html/text-value-as-html.component.ts
+++ b/projects/knora/viewer/src/lib/property/text-value/text-value-as-html/text-value-as-html.component.ts
@@ -1,5 +1,6 @@
 import { Component, ElementRef, EventEmitter, HostListener, Input, Output } from '@angular/core';
-import { KnoraConstants, OntologyInformation, ReadTextValueAsHtml } from '@knora/core';
+import { KnoraConstants, OntologyInformation } from '@knora/core';
+import { ReadTextValueAsHtml } from '@knora/api';
 
 @Component({
     selector: 'kui-text-value-as-html',

--- a/projects/knora/viewer/src/lib/property/text-value/text-value-as-string/text-value-as-string.component.html
+++ b/projects/knora/viewer/src/lib/property/text-value/text-value-as-string/text-value-as-string.component.html
@@ -1,1 +1,1 @@
-<span [innerHTML]="valueObject.str"></span>
+<span [innerHTML]="valueObject.strval"></span>

--- a/projects/knora/viewer/src/lib/property/text-value/text-value-as-string/text-value-as-string.component.ts
+++ b/projects/knora/viewer/src/lib/property/text-value/text-value-as-string/text-value-as-string.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { ReadTextValueAsString } from '@knora/core';
+import { ReadTextValueAsString } from '@knora/api';
 
 @Component({
     selector: 'kui-text-value-as-string',
@@ -14,12 +14,12 @@ export class TextValueAsStringComponent {
     set valueObject(value: ReadTextValueAsString) {
         // console.log(value);
 
-        const str: string = value.str;
+        const str: string = value.strval;
 
         if (this.regexUrl.exec(str)) {
             const url: string = this.regexUrl.exec(str)[0];
             const newStr = str.replace(this.regexUrl, '<a class="kui-link" href="' + url + '">' + url + '</a>');
-            value.str = newStr;
+            value.strval = newStr;
             this._textStringValueObj = value;
         } else {
             this._textStringValueObj = value;
@@ -34,7 +34,7 @@ export class TextValueAsStringComponent {
 
     private _textStringValueObj: ReadTextValueAsString;
 
-    constructor () {
+    constructor() {
     }
 
 }

--- a/projects/knora/viewer/src/lib/property/textfile-value/textfile-value.component.html
+++ b/projects/knora/viewer/src/lib/property/textfile-value/textfile-value.component.html
@@ -1,1 +1,1 @@
-<a target="_blank" href="{{valueObject.textFileURL}}">{{valueObject.textFilename}}</a>
+<a target="_blank" href="{{valueObject.fileUrl}}">{{valueObject.filename}}</a>

--- a/projects/knora/viewer/src/lib/property/textfile-value/textfile-value.component.ts
+++ b/projects/knora/viewer/src/lib/property/textfile-value/textfile-value.component.ts
@@ -1,24 +1,24 @@
 import { Component, Input } from '@angular/core';
-import { ReadTextFileValue } from '@knora/core';
+import { ReadFileValue } from '@knora/api';
 
 @Component({
-  selector: 'kui-textfile-value',
-  templateUrl: './textfile-value.component.html',
-  styleUrls: ['./textfile-value.component.scss']
+    selector: 'kui-textfile-value',
+    templateUrl: './textfile-value.component.html',
+    styleUrls: ['./textfile-value.component.scss']
 })
 export class TextfileValueComponent {
 
-  @Input()
-  set valueObject(value: ReadTextFileValue) {
-    this._textfileValueObj = value;
-  }
+    @Input()
+    set valueObject(value: ReadFileValue) {
+        this._textfileValueObj = value;
+    }
 
-  get valueObject() {
-    return this._textfileValueObj;
-  }
+    get valueObject() {
+        return this._textfileValueObj;
+    }
 
-  private _textfileValueObj: ReadTextFileValue;
+    private _textfileValueObj: ReadFileValue;
 
-  constructor() { }
+    constructor() { }
 
 }

--- a/projects/knora/viewer/src/lib/property/uri-value/uri-value.component.ts
+++ b/projects/knora/viewer/src/lib/property/uri-value/uri-value.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnChanges } from '@angular/core';
-import { ReadUriValue } from '@knora/core';
+import { ReadUriValue } from '@knora/api';
 
 @Component({
     selector: '   kui-uri-value',
@@ -19,7 +19,7 @@ export class UriValueComponent implements OnChanges {
     @Input() label?: string;
     private __uriValueObj: ReadUriValue;
     public displayString: string;
-    constructor () { }
+    constructor() { }
 
     ngOnChanges() {
         if (this.label === undefined) {

--- a/projects/knora/viewer/src/lib/resource/still-image/still-image.component.scss
+++ b/projects/knora/viewer/src/lib/resource/still-image/still-image.component.scss
@@ -1,5 +1,5 @@
 // sizes
-$max-width: 800px;
+$max-width: 960px;
 $nav-width: 36px;
 
 $osd-width: calc(100% - (2 * #{$nav-width}));
@@ -60,26 +60,26 @@ $bright: #ccc;
   }
 }
 
-
 /*
  Overlay styling
  */
 
- ::ng-deep .roi-svgoverlay {
+::ng-deep .roi-svgoverlay {
   filter: alpha(opacity=40);
   opacity: 0.4;
   fill: transparent;
-  stroke: #00695C;
+  stroke: #00695c;
   stroke-width: 2px;
   vector-effect: non-scaling-stroke;
 }
 
-::ng-deep .roi-svgoverlay:hover, .roi-svgoverlay:focus {
+::ng-deep .roi-svgoverlay:hover,
+.roi-svgoverlay:focus {
   filter: alpha(opacity=100);
-  opacity: 1.0;
+  opacity: 1;
 }
 
 ::ng-deep .roi-svgoverlay.active {
   filter: alpha(opacity=100);
-  opacity: 1.0;
+  opacity: 1;
 }

--- a/projects/knora/viewer/src/lib/resource/still-image/still-image.component.ts
+++ b/projects/knora/viewer/src/lib/resource/still-image/still-image.component.ts
@@ -1,5 +1,6 @@
 import { Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChange } from '@angular/core';
-import { KnoraConstants, Point2D, ReadGeomValue, ReadResource, ReadStillImageFileValue, Region, RegionGeometry } from '@knora/core';
+import { KnoraConstants, Point2D, ReadGeomValue, ReadResource, Region, RegionGeometry } from '@knora/core';
+import { ReadStillImageFileValue } from '@knora/api';
 
 
 // This component needs the openseadragon library itself, as well as the openseadragon plugin openseadragon-svg-overlay
@@ -20,7 +21,7 @@ export class ImageRegion {
      *
      * @param regionResource a resource of type Region
      */
-    constructor (readonly regionResource: ReadResource) {
+    constructor(readonly regionResource: ReadResource) {
 
     }
 
@@ -44,7 +45,7 @@ export class StillImageRepresentation {
      * @param stillImageFileValue a [[ReadStillImageFileValue]] representing an image.
      * @param regions the regions belonging to the image.
      */
-    constructor (readonly stillImageFileValue: ReadStillImageFileValue, readonly regions: Region[]) {
+    constructor(readonly stillImageFileValue: ReadStillImageFileValue, readonly regions: Region[]) {
 
     }
 
@@ -60,7 +61,7 @@ export class GeometryForRegion {
      * @param geometry the geometrical information.
      * @param region the region the geometry belongs to.
      */
-    constructor (readonly geometry: RegionGeometry, readonly region: ReadResource) {
+    constructor(readonly geometry: RegionGeometry, readonly region: ReadResource) {
     }
 
 }
@@ -86,7 +87,7 @@ interface PolygonsForRegion {
 })
 export class StillImageComponent implements OnInit, OnChanges, OnDestroy {
 
-    @Input() images: StillImageRepresentation[];
+    @Input() images: ReadStillImageFileValue[];
     @Input() imageCaption?: string;
     @Input() activateRegion: string; // highlight a region
 
@@ -128,7 +129,7 @@ export class StillImageComponent implements OnInit, OnChanges, OnDestroy {
         const tileSources = [];
 
         for (const image of imagesToDisplay) {
-            const sipiBasePath = image.imageServerIIIFBaseURL + '/' + image.imageFilename;
+            const sipiBasePath = image.iiifBaseUrl + '/' + image.filename;
             const width = image.dimX;
             const height = image.dimY;
 
@@ -159,7 +160,7 @@ export class StillImageComponent implements OnInit, OnChanges, OnDestroy {
         return tileSources;
     }
 
-    constructor (private elementRef: ElementRef) {
+    constructor(private elementRef: ElementRef) {
     }
 
     ngOnChanges(changes: { [key: string]: SimpleChange }) {
@@ -285,8 +286,8 @@ export class StillImageComponent implements OnInit, OnChanges, OnDestroy {
         });
 
         const fileValues: ReadStillImageFileValue[] = this.images.map(
-            (img) => {
-                return img.stillImageFileValue;
+            (img: ReadStillImageFileValue) => {
+                return img;
             });
 
         this.viewer.addHandler('page', function (event) {
@@ -316,8 +317,8 @@ export class StillImageComponent implements OnInit, OnChanges, OnDestroy {
         // see also: https://openseadragon.github.io/examples/viewport-coordinates/
 
         const fileValues: ReadStillImageFileValue[] = this.images.map(
-            (img) => {
-                return img.stillImageFileValue;
+            (img: ReadStillImageFileValue) => {
+                return img;
             });
 
         // display only the defined range of this.images
@@ -359,10 +360,11 @@ export class StillImageComponent implements OnInit, OnChanges, OnDestroy {
         let imageXOffset = 0; // see documentation in this.openImages() for the usage of imageXOffset
 
         for (const image of this.images) {
-            const aspectRatio = (image.stillImageFileValue.dimY / image.stillImageFileValue.dimX);
+            const aspectRatio = (image.dimY / image.dimX);
 
             // collect all geometries belonging to this page
             const geometries: GeometryForRegion[] = [];
+            /* TODO: knora-api-js-lib integration needs another region handling?
             image.regions.map((reg) => {
 
                 this.regions[reg.regionResource.id] = [];
@@ -405,6 +407,7 @@ export class StillImageComponent implements OnInit, OnChanges, OnDestroy {
                 this.createSVGOverlay(geom.region.id, geometry, aspectRatio, imageXOffset, geom.region.label);
 
             }
+            */
 
             imageXOffset++;
         }

--- a/projects/knora/viewer/src/lib/view/grid-view/grid-view.component.html
+++ b/projects/knora/viewer/src/lib/view/grid-view/grid-view.component.html
@@ -3,32 +3,22 @@
 
     <div fxLayout="row wrap" fxLayout.xs="column" fxLayoutGap="grid">
 
-        <div fxFlex.sm="50" fxFlex.md="33.3" fxFlex.lg="20" fxFlex.xl="16.6" fxFlex="16.6" *ngFor="let res of result"
+        <div fxFlex.xs="100" fxFlex.sm="50" fxFlex.md="33.3" fxFlex.lg="25" fxFlex.xl="20" *ngFor="let res of result"
              class="gv-preview">
             <mat-card class="link" (click)="openResource(res.id)">
 
-                <mat-card-subtitle>{{ontologyInfo?.getLabelForResourceClass(res.type)}}</mat-card-subtitle>
+                <mat-card-subtitle>{{res.entityInfo.classes[res.type].label}}</mat-card-subtitle>
                 <mat-card-title>{{res.label}}</mat-card-title>
 
 
                 <mat-card-content *ngFor="let prop of res.properties | kuiKey">
-                    <!-- description -->
                     <div *ngFor="let val of prop.value | kuiKey">
-                        <div [ngSwitch]="val.value.getClassName()">
-                            <div class="lv-html-text" *ngSwitchCase="KnoraConstants.ReadTextValueAsHtml">
-                                <kui-text-value-as-html [valueObject]="val.value" [ontologyInfo]="ontologyInfo"
-                                                        [bindEvents]="false"></kui-text-value-as-html>
-                                <p class="lv-read-more"></p>
-                            </div>
-                            <div>
-                                <kui-date-value *ngSwitchCase="KnoraConstants.ReadDateValue" [valueObject]="val.value"
-                                                [calendar]="true" [era]="true"></kui-date-value>
-                                <span *ngSwitchDefault="">{{val.value.getContent()}}</span>
-                            </div>
-                            <br>
-                            <span *ngIf="ontologyInfo?.getLabelForProperty(prop.key) !== 'Text'">
-                                {{ontologyInfo?.getLabelForProperty(prop.key)}}
-                            </span>
+                        <span class="lv-prop-label">
+                            {{res.entityInfo.properties[val.value.property].label}}:&nbsp;
+                        </span>
+
+                        <div class="lv-html-text">
+                            {{val.value.strval | kuiTruncate:['256', '...']}}
                         </div>
                     </div>
                 </mat-card-content>

--- a/projects/knora/viewer/src/lib/view/grid-view/grid-view.component.scss
+++ b/projects/knora/viewer/src/lib/view/grid-view/grid-view.component.scss
@@ -1,30 +1,29 @@
-@import '../../assets/style/viewer';
+@import "../../assets/style/viewer";
 
 .gv-preview {
-    margin: 6px 0;
-    padding: 24px;
-    word-wrap: break-word;
-    border-radius: 5px;
-  
-    .mat-card {
-      height: 160px;
-      color: rgba(0, 0, 0, 0.81);
-      overflow: hidden;
-      padding-bottom: 25px; 
-  
-      &:hover {
-        background: rgba($primary, 0.39);
-        color: rgba(0, 0, 0, 1);
-      }
-  
-      &:active {
-        background: rgba($primary, 0.61);
-      }
+  margin: 6px 0;
+  padding: 24px;
+  word-wrap: break-word;
+  border-radius: 5px;
 
-      .mat-card-title {
-        font-size: 12pt;
-        font-weight: 600;
-      }
-  
+  .mat-card {
+    height: 180px;
+    color: rgba(0, 0, 0, 0.81);
+    overflow: hidden;
+    padding-bottom: 25px;
+
+    &:hover {
+      background: rgba($primary, 0.39);
+      color: rgba(0, 0, 0, 1);
     }
+
+    &:active {
+      background: rgba($primary, 0.61);
+    }
+
+    .mat-card-title {
+      font-size: 12pt;
+      font-weight: 600;
+    }
+  }
 }

--- a/projects/knora/viewer/src/lib/view/grid-view/grid-view.component.ts
+++ b/projects/knora/viewer/src/lib/view/grid-view/grid-view.component.ts
@@ -3,39 +3,39 @@ import { KnoraConstants, OntologyInformation } from '@knora/core';
 import { Router } from '@angular/router';
 
 @Component({
-  selector: 'kui-grid-view',
-  templateUrl: './grid-view.component.html',
-  styleUrls: ['./grid-view.component.scss']
+    selector: 'kui-grid-view',
+    templateUrl: './grid-view.component.html',
+    styleUrls: ['./grid-view.component.scss']
 })
 export class GridViewComponent implements OnInit {
 
-  /**
-   * @param  {any} result Search result received from SearchResultsComponent
-   */
-  @Input() result: any;
+    /**
+     * @param  {any} result Search result received from SearchResultsComponent
+     */
+    @Input() result: any;
 
-  /**
-   * @param  {OntologyInformation} ontologyInfo Ontology information received from SearchResultsComponent
-   */
-  @Input() ontologyInfo: OntologyInformation;
+    /**
+     * @param  {OntologyInformation} ontologyInfo Ontology information received from SearchResultsComponent
+     */
+    @Input() ontologyInfo: OntologyInformation;
 
-  // @Input() isLoading: boolean;
+    // @Input() isLoading: boolean;
 
-  KnoraConstants = KnoraConstants;
+    KnoraConstants = KnoraConstants;
 
-  constructor(
-    private _router: Router
-  ) { }
+    constructor(
+        private _router: Router
+    ) { }
 
-  ngOnInit() {
-  }
+    ngOnInit() {
+    }
 
-  /**
-   * Navigate to the resource viewer when clicking on one resource of the search result grid
-   * @param {string} id 
-   */
-  openResource(id: string) {
-    const url: string = '/resource/' + encodeURIComponent(id);
-    this._router.navigate([url]);
-  }
+    /**
+     * Navigate to the resource viewer when clicking on one resource of the search result grid
+     * @param {string} id
+     */
+    openResource(id: string) {
+        const url: string = '/resource/' + encodeURIComponent(id);
+        this._router.navigate([url]);
+    }
 }

--- a/projects/knora/viewer/src/lib/view/list-view/list-view.component.html
+++ b/projects/knora/viewer/src/lib/view/list-view/list-view.component.html
@@ -4,33 +4,19 @@
     <mat-list class="list-view lv-items" *ngFor="let res of result; let i = index; let last = last;">
         <mat-list-item class="link" (click)="openResource(res.id)">
             <mat-icon matListIcon>image_search</mat-icon>
-            <p matLine class="lv-res-label">{{ontologyInfo?.getLabelForResourceClass(res.type)}}</p>
+            <p matLine class="lv-res-label">{{res.entityInfo.classes[res.type].label}}</p>
             <h3 matLine class="lv-label">{{res.label}}</h3>
 
             <div matLine *ngFor="let prop of res.properties | kuiKey">
 
                 <div matLine *ngFor="let val of prop.value | kuiKey">
 
-                    <div [ngSwitch]="val.value.getClassName()">
-                        <span *ngIf="ontologyInfo?.getLabelForProperty(prop.key) !== 'Text'" class="lv-prop-label">
-                            {{ontologyInfo?.getLabelForProperty(prop.key)}}:&nbsp;
-                        </span>
+                    <span class="lv-prop-label">
+                        {{res.entityInfo.properties[val.value.property].label}}:&nbsp;
+                    </span>
 
-                        <div class="lv-html-text">
-
-                            <div *ngSwitchCase="KnoraConstants.ReadTextValueAsHtml">
-                                <kui-text-value-as-html [valueObject]="val.value" [ontologyInfo]="ontologyInfo" [bindEvents]="false"></kui-text-value-as-html>
-                            </div>
-
-                            <kui-date-value *ngSwitchCase="KnoraConstants.ReadDateValue" [valueObject]="val.value" [calendar]="true" [era]="true"></kui-date-value>
-
-                            <span *ngSwitchDefault="">{{val.value.getContent()}}</span>
-
-                            <!-- slice the end of long texts -->
-                            <p class="lv-read-more"></p>
-
-                        </div>
-
+                    <div class="lv-html-text">
+                        {{val.value.strval | kuiTruncate:['256', '...']}}
                     </div>
 
                 </div>

--- a/projects/knora/viewer/src/lib/view/list-view/list-view.component.ts
+++ b/projects/knora/viewer/src/lib/view/list-view/list-view.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { KnoraConstants, OntologyInformation } from '@knora/core';
 import { Router } from '@angular/router';
+import { IResourceClassAndPropertyDefinitions, ReadResource } from '@knora/api';
 
 @Component({
     selector: 'kui-list-view',
@@ -12,12 +13,12 @@ export class ListViewComponent {
     /**
      * @param  {any} result Search result received from SearchResultsComponent
      */
-    @Input() result: any;
+    @Input() result: ReadResource[];
 
     /**
-     * @param  {OntologyInformation} ontologyInfo Ontology information received from SearchResultsComponent
+     * @param  {IResourceClassAndPropertyDefinitions} ontologyInfo Ontology information received from SearchResultsComponent
      */
-    @Input() ontologyInfo: OntologyInformation;
+    @Input() ontologyInfo: IResourceClassAndPropertyDefinitions;
 
     // @Input() isLoading: boolean;
 
@@ -25,7 +26,9 @@ export class ListViewComponent {
 
     constructor(
         private _router: Router
-    ) { }
+    ) {
+
+    }
 
     /**
      * Navigate to the resource viewer when clicking on one resource of the search result list

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.html
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.html
@@ -1,1 +1,31 @@
-This resource belongs to {{project.shortname}}
+<div class="toolbar" *ngIf="project">
+    <!-- project info -->
+    <h3 class="label mat-subheading-1">This source belongs to
+        <a [href]="'/project/' + project.shortcode">
+            {{project.shortname}}
+            <mat-icon inline>open_in_new</mat-icon>
+        </a>
+    </h3>
+    <!-- open_in_new icon -->
+    <span class="fill-remaining-space"></span>
+
+    <!-- tools: share, add to favorites, edit, delete etc. -->
+    <span>
+        <button mat-button>
+            <mat-icon>star_border</mat-icon>
+        </button>
+
+        <button mat-button>
+            <mat-icon>edit</mat-icon>
+        </button>
+
+        <button mat-button>
+            <mat-icon>delete</mat-icon>
+        </button>
+
+        <button mat-button>
+            <mat-icon>share</mat-icon>
+        </button>
+    </span>
+
+</div>

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.html
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.html
@@ -1,0 +1,1 @@
+This resource belongs to {{project.shortname}}

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.html
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.html
@@ -15,7 +15,7 @@
             <mat-icon>star_border</mat-icon>
         </button>
 
-        <button mat-button (click)="toggleProps.emit(!showAllProps)">
+        <button mat-button (click)="toggleProps.emit(!allProps)">
             <mat-icon>edit</mat-icon>
         </button>
 

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.html
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.html
@@ -15,7 +15,7 @@
             <mat-icon>star_border</mat-icon>
         </button>
 
-        <button mat-button>
+        <button mat-button (click)="toggleProps.emit(!showAllProps)">
             <mat-icon>edit</mat-icon>
         </button>
 

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.scss
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.scss
@@ -1,0 +1,15 @@
+.toolbar {
+  display: flex;
+  box-sizing: border-box;
+  flex-direction: row;
+  align-items: center;
+  white-space: nowrap;
+  padding: 0 16px;
+  width: 100%;
+  background: whitesmoke;
+  color: rgba(0, 0, 0, 0.87);
+
+  .label {
+    margin: 0 !important;
+  }
+}

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.spec.ts
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PropertiesToolbarComponent } from './properties-toolbar.component';
+
+describe('PropertiesToolbarComponent', () => {
+  let component: PropertiesToolbarComponent;
+  let fixture: ComponentFixture<PropertiesToolbarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PropertiesToolbarComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PropertiesToolbarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.ts
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.ts
@@ -1,0 +1,34 @@
+import { Component, Inject, Input, OnInit } from '@angular/core';
+import { ApiResponseData, ApiResponseError, KnoraApiConnection, ProjectResponse, ReadProject } from '@knora/api';
+import { KnoraApiConnectionToken } from '@knora/core';
+
+@Component({
+    selector: 'kui-properties-toolbar',
+    templateUrl: './properties-toolbar.component.html',
+    styleUrls: ['./properties-toolbar.component.scss']
+})
+export class PropertiesToolbarComponent implements OnInit {
+
+    @Input() projectiri: string;
+    @Input() ontologyiri: string;
+    @Input() arkurl: string;
+
+    project: ReadProject;
+
+    constructor(
+        @Inject(KnoraApiConnectionToken) private knoraApiConnection: KnoraApiConnection
+    ) { }
+
+    ngOnInit() {
+        // get project information
+        this.knoraApiConnection.admin.projectsEndpoint.getProjectByIri(this.projectiri).subscribe(
+            (response: ApiResponseData<ProjectResponse>) => {
+                this.project = response.body.project;
+            },
+            (error: ApiResponseError) => {
+                console.error(error);
+            }
+        )
+    }
+
+}

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.ts
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.ts
@@ -13,7 +13,7 @@ export class PropertiesToolbarComponent implements OnInit {
     @Input() ontologyiri: string;
     @Input() arkurl: string;
 
-    @Input() showAllProps: boolean;
+    @Input() allProps: boolean;
 
     @Output() toggleProps: EventEmitter<boolean> = new EventEmitter<boolean>();
 

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.ts
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-toolbar/properties-toolbar.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, Input, OnInit } from '@angular/core';
+import { Component, EventEmitter, Inject, Input, OnInit, Output } from '@angular/core';
 import { ApiResponseData, ApiResponseError, KnoraApiConnection, ProjectResponse, ReadProject } from '@knora/api';
 import { KnoraApiConnectionToken } from '@knora/core';
 
@@ -12,6 +12,10 @@ export class PropertiesToolbarComponent implements OnInit {
     @Input() projectiri: string;
     @Input() ontologyiri: string;
     @Input() arkurl: string;
+
+    @Input() showAllProps: boolean;
+
+    @Output() toggleProps: EventEmitter<boolean> = new EventEmitter<boolean>();
 
     project: ReadProject;
 

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.html
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.html
@@ -1,5 +1,7 @@
+<!-- header with project / ontology / resource class info / ark url -->
+
 <!-- properties -->
-<div class="properties">
+<div class="properties" *ngIf="!loading">
     <!-- let prop of guiOrder (was previous; has to be reset again) -->
     <div *ngFor="let prop of propArray | kuiKey; let last = last">
         <div *ngIf="properties[prop?.val.property]" class="property">

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.html
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.html
@@ -24,6 +24,7 @@
 
                         <span *ngIf="prop.values" [class.list]="prop.values.length > 1"
                               [class.lastItem]="lastItem">{{val.strval}}</span>
+
                         <!-- TODO: reactivate switch by value type as soon the new viewer elements are ready -->
                         <!--
                     <span [ngSwitch]="val.type" [class.list]="prop.values.length > 1" [class.lastItem]="lastItem">

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.html
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.html
@@ -1,12 +1,10 @@
-<!-- header with project / ontology / resource class info / ark url -->
-<kui-properties-toolbar [projectiri]="resource.attachedToProject"></kui-properties-toolbar>
 <!-- properties -->
 <div class="properties" *ngIf="loading">
     <!-- let prop of guiOrder (was previous; has to be reset again) -->
     <div *ngFor="let prop of propArray; let last = last">
         <!-- TODO: add switch to show all properties or to hide empty properties -->
         <!-- *ngIf="prop.values" -->
-        <div class="property">
+        <div class="property" *ngIf="!HasFileRepresentation.includes(prop.guiDef.propertyIndex)">
             <div class="property-label">
                 <!-- label of the property -->
                 <h3 class="label mat-subheading-1">
@@ -17,21 +15,23 @@
 
                 <!-- the value(s) of the property -->
                 <div class="property-value-item" *ngFor="let val of prop.values; let lastItem = last">
+
+                    <span [class.list]="prop.values.length > 1" [class.lastItem]="lastItem">{{val.strval}}</span>
+
+                    <!-- TODO: reactivate switch by value type -->
+                    <!--
                     <span [ngSwitch]="val.type" [class.list]="prop.values.length > 1" [class.lastItem]="lastItem">
                         <kui-text-value-as-string *ngSwitchCase="KnoraConstants.TextValue" [valueObject]="val">
                         </kui-text-value-as-string>
                         <kui-text-value-as-xml *ngSwitchCase="KnoraConstants.TextValueAsXml" [valueObject]="val">
                         </kui-text-value-as-xml>
-                        <!--
                         <kui-date-value *ngSwitchCase="KnoraConstants.ReadDateValue" [valueObject]="val"
                                         [calendar]="true" [era]="true">
                         </kui-date-value>
-                    -->
-                        <!-- [ontologyInfo]="ontologyInfo" -->
-                        <!-- <kui-link-value class="app-link" *ngSwitchCase="KnoraConstants.ReadLinkValue"
+                        <kui-link-value class="app-link" *ngSwitchCase="KnoraConstants.ReadLinkValue"
                                         [valueObject]="val"
                                         (referredResourceClicked)="openLink(val.referredResourceIri)">
-                        </kui-link-value> -->
+                        </kui-link-value>
                         <kui-integer-value *ngSwitchCase="KnoraConstants.IntValue" [valueObject]="val">
                         </kui-integer-value>
                         <kui-decimal-value *ngSwitchCase="KnoraConstants.DecimalValue" [valueObject]="val">
@@ -46,13 +46,14 @@
                         </kui-boolean-value>
                         <kui-interval-value *ngSwitchCase="KnoraConstants.IntervalValue" [valueObject]="val">
                         </kui-interval-value>
-                        <!-- <kui-list-value *ngSwitchCase="KnoraConstants.ReadListValue" [valueObject]="val">
-                        </kui-list-value> -->
+                        <kui-list-value *ngSwitchCase="KnoraConstants.ReadListValue" [valueObject]="val">
+                        </kui-list-value>
                         <kui-textfile-value *ngSwitchCase="KnoraConstants.FileValueHasFilename" [valueObject]="val">
                         </kui-textfile-value>
                         <span *ngSwitchDefault>Not supported {{val.type}}</span>
                         <br>
                     </span>
+                    -->
                 </div>
             </div>
         </div>

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.html
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.html
@@ -1,26 +1,31 @@
+<kui-properties-toolbar *ngIf="toolbar" [projectiri]="resource.attachedToProject" [allProps]="allProps"
+                        (toggleProps)="toggleProps($event)">
+</kui-properties-toolbar>
 <!-- properties -->
-<div class="properties" *ngIf="!loading">
-    <!-- let prop of guiOrder (was previous; has to be reset again) -->
-    <div *ngFor="let prop of propArray; let last = last">
-        <!-- TODO: add switch to show all properties or to hide empty properties -->
-        <!-- *ngIf="prop.values" -->
-        <!-- show property; anyway in case of showAll === true or if prop.values is not undefined -->
-        <div class="property" *ngIf="showAll || prop.values">
-            <div class="property-label">
-                <!-- label of the property -->
-                <h3 class="label mat-subheading-1">
-                    {{prop.propDef.label}}
-                </h3>
-            </div>
-            <div class="property-value">
+<div class="properties-container">
+    <div class="properties" *ngIf="!loading">
 
-                <!-- the value(s) of the property -->
-                <div class="property-value-item" *ngFor="let val of prop.values; let lastItem = last">
+        <!-- list of properties -->
+        <div *ngFor="let prop of propArray; let last = last">
+            <!-- TODO: add switch to show all properties or to hide empty properties -->
+            <!-- *ngIf="prop.values" -->
+            <!-- show property; anyway in case of showAll === true or if prop.values is not undefined -->
+            <div class="property" *ngIf="allProps || prop.values">
+                <div class="property-label">
+                    <!-- label of the property -->
+                    <h3 class="label mat-subheading-1">
+                        {{prop.propDef.label}}
+                    </h3>
+                </div>
+                <div class="property-value">
 
-                    <span *ngIf="prop.values" [class.list]="prop.values.length > 1"
-                          [class.lastItem]="lastItem">{{val.strval}}</span>
-                    <!-- TODO: reactivate switch by value type as soon the new viewer elements are ready -->
-                    <!--
+                    <!-- the value(s) of the property -->
+                    <div class="property-value-item" *ngFor="let val of prop.values; let lastItem = last">
+
+                        <span *ngIf="prop.values" [class.list]="prop.values.length > 1"
+                              [class.lastItem]="lastItem">{{val.strval}}</span>
+                        <!-- TODO: reactivate switch by value type as soon the new viewer elements are ready -->
+                        <!--
                     <span [ngSwitch]="val.type" [class.list]="prop.values.length > 1" [class.lastItem]="lastItem">
                         <kui-text-value-as-string *ngSwitchCase="KnoraConstants.TextValue" [valueObject]="val">
                         </kui-text-value-as-string>
@@ -55,41 +60,41 @@
                         <br>
                     </span>
                     -->
+                    </div>
                 </div>
             </div>
         </div>
+
+
+        <!-- TODO / QUESTION: What happend to incoming links and annotations? -->
+        <div class="incoming">
+
+            <!-- annotations are resources like region, sequence etc. -->
+            <!-- TODO: we can't display incoming annotations as expected
+            <div class="annotations">
+                <!-- *ngIf="annotations?.length > 0"> --
+                <h3 class="label mat-subheading-1">
+                    Annotations
+                </h3>
+                <mat-list *ngFor="let annotation of annotations">
+                    <mat-list-item class="kui-link" (click)="openLink(annotation.id)">
+                        <span>{{annotation.label}}</span>
+                    </mat-list-item>
+                </mat-list>
+            </div>
+            -->
+
+            <!-- incoming links -->
+            <!-- <div class="links" *ngIf="incomingLinks?.length > 0">
+                <h3 class="label mat-subheading-1">
+                    Links
+                </h3>
+                <ul>
+                    <li *ngFor="let incoming of incomingLinks" class="kui-link" (click)="openLink(incoming.id)">
+                        {{incoming.label}}
+                    </li>
+                </ul>
+            </div> -->
+        </div>
     </div>
-
-</div>
-
-<!-- TODO / QUESTION: What happens to incoming links and annotations? -->
-
-<div class="incoming">
-
-    <!-- annotations are resources like region, sequence etc. -->
-    <!-- TODO: we can't display incoming annotations as expected
-    <div class="annotations">
-        <!-- *ngIf="annotations?.length > 0"> --
-        <h3 class="label mat-subheading-1">
-            Annotations
-        </h3>
-        <mat-list *ngFor="let annotation of annotations">
-            <mat-list-item class="kui-link" (click)="openLink(annotation.id)">
-                <span>{{annotation.label}}</span>
-            </mat-list-item>
-        </mat-list>
-    </div>
-    -->
-
-    <!-- incoming links -->
-    <!-- <div class="links" *ngIf="incomingLinks?.length > 0">
-        <h3 class="label mat-subheading-1">
-            Links
-        </h3>
-        <ul>
-            <li *ngFor="let incoming of incomingLinks" class="kui-link" (click)="openLink(incoming.id)">
-                {{incoming.label}}
-            </li>
-        </ul>
-    </div> -->
 </div>

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.html
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.html
@@ -1,15 +1,10 @@
-<kui-properties-toolbar *ngIf="toolbar" [projectiri]="resource.attachedToProject" [allProps]="allProps"
-                        (toggleProps)="toggleProps($event)">
-</kui-properties-toolbar>
 <!-- properties -->
 <div class="properties-container">
     <div class="properties" *ngIf="!loading">
 
         <!-- list of properties -->
         <div *ngFor="let prop of propArray; let last = last">
-            <!-- TODO: add switch to show all properties or to hide empty properties -->
-            <!-- *ngIf="prop.values" -->
-            <!-- show property; anyway in case of showAll === true or if prop.values is not undefined -->
+            <!-- show property; all in case of showAll === true or only the ones with prop.values -->
             <div class="property" *ngIf="allProps || prop.values">
                 <div class="property-label">
                     <!-- label of the property -->
@@ -27,40 +22,40 @@
 
                         <!-- TODO: reactivate switch by value type as soon the new viewer elements are ready -->
                         <!--
-                    <span [ngSwitch]="val.type" [class.list]="prop.values.length > 1" [class.lastItem]="lastItem">
-                        <kui-text-value-as-string *ngSwitchCase="KnoraConstants.TextValue" [valueObject]="val">
-                        </kui-text-value-as-string>
-                        <kui-text-value-as-xml *ngSwitchCase="KnoraConstants.TextValueAsXml" [valueObject]="val">
-                        </kui-text-value-as-xml>
-                        <kui-date-value *ngSwitchCase="KnoraConstants.ReadDateValue" [valueObject]="val"
-                                        [calendar]="true" [era]="true">
-                        </kui-date-value>
-                        <kui-link-value class="app-link" *ngSwitchCase="KnoraConstants.ReadLinkValue"
-                                        [valueObject]="val"
-                                        (referredResourceClicked)="openLink(val.referredResourceIri)">
-                        </kui-link-value>
-                        <kui-integer-value *ngSwitchCase="KnoraConstants.IntValue" [valueObject]="val">
-                        </kui-integer-value>
-                        <kui-decimal-value *ngSwitchCase="KnoraConstants.DecimalValue" [valueObject]="val">
-                        </kui-decimal-value>
-                        <kui-geometry-value *ngSwitchCase="KnoraConstants.GeomValue" [valueObject]="val">
-                        </kui-geometry-value>
-                        <kui-color-value *ngSwitchCase="KnoraConstants.ColorValue" [valueObject]="val">
-                        </kui-color-value>
-                        <kui-uri-value *ngSwitchCase="KnoraConstants.UriValue" [valueObject]="val">
-                        </kui-uri-value>
-                        <kui-boolean-value *ngSwitchCase="KnoraConstants.BooleanValue" [valueObject]="val">
-                        </kui-boolean-value>
-                        <kui-interval-value *ngSwitchCase="KnoraConstants.IntervalValue" [valueObject]="val">
-                        </kui-interval-value>
-                        <kui-list-value *ngSwitchCase="KnoraConstants.ReadListValue" [valueObject]="val">
-                        </kui-list-value>
-                        <kui-textfile-value *ngSwitchCase="KnoraConstants.FileValueHasFilename" [valueObject]="val">
-                        </kui-textfile-value>
-                        <span *ngSwitchDefault>Not supported {{val.type}}</span>
-                        <br>
-                    </span>
-                    -->
+                        <span [ngSwitch]="val.type" [class.list]="prop.values.length > 1" [class.lastItem]="lastItem">
+                            <kui-text-value-as-string *ngSwitchCase="KnoraConstants.TextValue" [valueObject]="val">
+                            </kui-text-value-as-string>
+                            <kui-text-value-as-xml *ngSwitchCase="KnoraConstants.TextValueAsXml" [valueObject]="val">
+                            </kui-text-value-as-xml>
+                            <kui-date-value *ngSwitchCase="KnoraConstants.ReadDateValue" [valueObject]="val"
+                                            [calendar]="true" [era]="true">
+                            </kui-date-value>
+                            <kui-link-value class="app-link" *ngSwitchCase="KnoraConstants.ReadLinkValue"
+                                            [valueObject]="val"
+                                            (referredResourceClicked)="openLink(val.referredResourceIri)">
+                            </kui-link-value>
+                            <kui-integer-value *ngSwitchCase="KnoraConstants.IntValue" [valueObject]="val">
+                            </kui-integer-value>
+                            <kui-decimal-value *ngSwitchCase="KnoraConstants.DecimalValue" [valueObject]="val">
+                            </kui-decimal-value>
+                            <kui-geometry-value *ngSwitchCase="KnoraConstants.GeomValue" [valueObject]="val">
+                            </kui-geometry-value>
+                            <kui-color-value *ngSwitchCase="KnoraConstants.ColorValue" [valueObject]="val">
+                            </kui-color-value>
+                            <kui-uri-value *ngSwitchCase="KnoraConstants.UriValue" [valueObject]="val">
+                            </kui-uri-value>
+                            <kui-boolean-value *ngSwitchCase="KnoraConstants.BooleanValue" [valueObject]="val">
+                            </kui-boolean-value>
+                            <kui-interval-value *ngSwitchCase="KnoraConstants.IntervalValue" [valueObject]="val">
+                            </kui-interval-value>
+                            <kui-list-value *ngSwitchCase="KnoraConstants.ReadListValue" [valueObject]="val">
+                            </kui-list-value>
+                            <kui-textfile-value *ngSwitchCase="KnoraConstants.FileValueHasFilename" [valueObject]="val">
+                            </kui-textfile-value>
+                            <span *ngSwitchDefault>Not supported {{val.type}}</span>
+                            <br>
+                        </span>
+                        -->
                     </div>
                 </div>
             </div>

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.html
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.html
@@ -1,10 +1,11 @@
 <!-- properties -->
-<div class="properties" *ngIf="loading">
+<div class="properties" *ngIf="!loading">
     <!-- let prop of guiOrder (was previous; has to be reset again) -->
     <div *ngFor="let prop of propArray; let last = last">
         <!-- TODO: add switch to show all properties or to hide empty properties -->
         <!-- *ngIf="prop.values" -->
-        <div class="property" *ngIf="!HasFileRepresentation.includes(prop.guiDef.propertyIndex)">
+        <!-- show property; anyway in case of showAll === true or if prop.values is not undefined -->
+        <div class="property" *ngIf="showAll || prop.values">
             <div class="property-label">
                 <!-- label of the property -->
                 <h3 class="label mat-subheading-1">
@@ -16,9 +17,9 @@
                 <!-- the value(s) of the property -->
                 <div class="property-value-item" *ngFor="let val of prop.values; let lastItem = last">
 
-                    <span [class.list]="prop.values.length > 1" [class.lastItem]="lastItem">{{val.strval}}</span>
-
-                    <!-- TODO: reactivate switch by value type -->
+                    <span *ngIf="prop.values" [class.list]="prop.values.length > 1"
+                          [class.lastItem]="lastItem">{{val.strval}}</span>
+                    <!-- TODO: reactivate switch by value type as soon the new viewer elements are ready -->
                     <!--
                     <span [ngSwitch]="val.type" [class.list]="prop.values.length > 1" [class.lastItem]="lastItem">
                         <kui-text-value-as-string *ngSwitchCase="KnoraConstants.TextValue" [valueObject]="val">
@@ -60,6 +61,9 @@
     </div>
 
 </div>
+
+<!-- TODO / QUESTION: What happens to incoming links and annotations? -->
+
 <div class="incoming">
 
     <!-- annotations are resources like region, sequence etc. -->
@@ -78,7 +82,7 @@
     -->
 
     <!-- incoming links -->
-    <div class="links" *ngIf="incomingLinks?.length > 0">
+    <!-- <div class="links" *ngIf="incomingLinks?.length > 0">
         <h3 class="label mat-subheading-1">
             Links
         </h3>
@@ -87,5 +91,5 @@
                 {{incoming.label}}
             </li>
         </ul>
-    </div>
+    </div> -->
 </div>

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.html
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.html
@@ -1,54 +1,56 @@
 <!-- header with project / ontology / resource class info / ark url -->
-
+<kui-properties-toolbar [projectiri]="resource.attachedToProject"></kui-properties-toolbar>
 <!-- properties -->
-<div class="properties" *ngIf="!loading">
+<div class="properties" *ngIf="loading">
     <!-- let prop of guiOrder (was previous; has to be reset again) -->
-    <div *ngFor="let prop of propArray | kuiKey; let last = last">
-        <div *ngIf="properties[prop?.val.property]" class="property">
+    <div *ngFor="let prop of propArray; let last = last">
+        <!-- TODO: add switch to show all properties or to hide empty properties -->
+        <!-- *ngIf="prop.values" -->
+        <div class="property">
             <div class="property-label">
                 <!-- label of the property -->
                 <h3 class="label mat-subheading-1">
-                    {{entityInfo.properties[prop.property].label}}
+                    {{prop.propDef.label}}
                 </h3>
             </div>
             <div class="property-value">
 
                 <!-- the value(s) of the property -->
-                <div class="property-value-item" *ngFor="let val of properties[prop.val.property]; let lastItem = last">
-                    <span [ngSwitch]="val.getClassName()" [class.list]="properties[prop.val.property].length > 1"
-                          [class.lastItem]="lastItem">
-                        <kui-text-value-as-string *ngSwitchCase="KnoraConstants.ReadTextValueAsString"
-                                                  [valueObject]="val">
+                <div class="property-value-item" *ngFor="let val of prop.values; let lastItem = last">
+                    <span [ngSwitch]="val.type" [class.list]="prop.values.length > 1" [class.lastItem]="lastItem">
+                        <kui-text-value-as-string *ngSwitchCase="KnoraConstants.TextValue" [valueObject]="val">
                         </kui-text-value-as-string>
-                        <kui-text-value-as-xml *ngSwitchCase="KnoraConstants.ReadTextValueAsXml" [valueObject]="val">
+                        <kui-text-value-as-xml *ngSwitchCase="KnoraConstants.TextValueAsXml" [valueObject]="val">
                         </kui-text-value-as-xml>
+                        <!--
                         <kui-date-value *ngSwitchCase="KnoraConstants.ReadDateValue" [valueObject]="val"
                                         [calendar]="true" [era]="true">
                         </kui-date-value>
+                    -->
                         <!-- [ontologyInfo]="ontologyInfo" -->
-                        <kui-link-value class="app-link" *ngSwitchCase="KnoraConstants.ReadLinkValue"
+                        <!-- <kui-link-value class="app-link" *ngSwitchCase="KnoraConstants.ReadLinkValue"
                                         [valueObject]="val"
                                         (referredResourceClicked)="openLink(val.referredResourceIri)">
-                        </kui-link-value>
-                        <kui-integer-value *ngSwitchCase="KnoraConstants.ReadIntegerValue" [valueObject]="val">
+                        </kui-link-value> -->
+                        <kui-integer-value *ngSwitchCase="KnoraConstants.IntValue" [valueObject]="val">
                         </kui-integer-value>
-                        <kui-decimal-value *ngSwitchCase="KnoraConstants.ReadDecimalValue" [valueObject]="val">
+                        <kui-decimal-value *ngSwitchCase="KnoraConstants.DecimalValue" [valueObject]="val">
                         </kui-decimal-value>
-                        <kui-geometry-value *ngSwitchCase="KnoraConstants.ReadGeomValue" [valueObject]="val">
+                        <kui-geometry-value *ngSwitchCase="KnoraConstants.GeomValue" [valueObject]="val">
                         </kui-geometry-value>
-                        <kui-color-value *ngSwitchCase="KnoraConstants.ReadColorValue" [valueObject]="val">
+                        <kui-color-value *ngSwitchCase="KnoraConstants.ColorValue" [valueObject]="val">
                         </kui-color-value>
-                        <kui-uri-value *ngSwitchCase="KnoraConstants.ReadUriValue" [valueObject]="val">
+                        <kui-uri-value *ngSwitchCase="KnoraConstants.UriValue" [valueObject]="val">
                         </kui-uri-value>
-                        <kui-boolean-value *ngSwitchCase="KnoraConstants.ReadBooleanValue" [valueObject]="val">
+                        <kui-boolean-value *ngSwitchCase="KnoraConstants.BooleanValue" [valueObject]="val">
                         </kui-boolean-value>
-                        <kui-interval-value *ngSwitchCase="KnoraConstants.ReadIntervalValue" [valueObject]="val">
+                        <kui-interval-value *ngSwitchCase="KnoraConstants.IntervalValue" [valueObject]="val">
                         </kui-interval-value>
-                        <kui-list-value *ngSwitchCase="KnoraConstants.ReadListValue" [valueObject]="val">
-                        </kui-list-value>
-                        <kui-textfile-value *ngSwitchCase="KnoraConstants.TextFileValue" [valueObject]="val">
+                        <!-- <kui-list-value *ngSwitchCase="KnoraConstants.ReadListValue" [valueObject]="val">
+                        </kui-list-value> -->
+                        <kui-textfile-value *ngSwitchCase="KnoraConstants.FileValueHasFilename" [valueObject]="val">
                         </kui-textfile-value>
-                        <span *ngSwitchDefault>Not supported {{val.getClassName()}}</span>
+                        <span *ngSwitchDefault>Not supported {{val.type}}</span>
                         <br>
                     </span>
                 </div>

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.scss
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.scss
@@ -1,6 +1,6 @@
 @import "../../assets/style/viewer";
 
-:host {
+.properties-container {
   display: grid;
   grid-template-columns: repeat(6, 1fr);
   //  grid-template-rows: repeat(2, auto);

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.ts
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.ts
@@ -22,9 +22,26 @@ export interface TempProperties {
 })
 export class PropertiesViewComponent implements OnInit {
 
+    /**
+     * Resource object
+     *
+     * @param  {ReadResource} resource
+     */
     @Input() resource: ReadResource;
 
-    @Input() showAll?: boolean = false;
+    /**
+     * Show all properties, even they don't have a value.
+     *
+     * @param  {boolean=false} [allProps]
+     */
+    @Input() allProps?: boolean = false;
+
+    /**
+     * Show toolbar with project info and some action tools
+     *
+     * @param  {boolean=false} [toolbar]
+     */
+    @Input() toolbar?: boolean = false;
 
     loading: boolean = true;
 
@@ -84,6 +101,11 @@ export class PropertiesViewComponent implements OnInit {
         // this.routeChanged.emit(id);
         this._router.navigate(['/resource/' + encodeURIComponent(id)]);
 
+    }
+
+
+    toggleProps(show: boolean) {
+        this.allProps = !this.allProps;
     }
 
 }

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.ts
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.ts
@@ -27,12 +27,14 @@ export class PropertiesViewComponent implements OnInit {
 
     propArray: TempProp[] = [];
 
+    // TODO: make a list of file value iri definitions, to filter in list of properties
+    HasFileRepresentation: string[] = [
+        Constants.KnoraApiV2 + Constants.Delimiter + 'hasStillImageFileValue'
+    ];
+
     // @Input() guiOrder?: GuiOrder;
 
     @Input() resource: ReadResource;
-
-
-
 
     // @Input() classType: string;
 

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.ts
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.ts
@@ -5,7 +5,7 @@ import { PropertyDefinition } from '@knora/api/src/models/v2/ontologies/property
 
 import { FileRepresentation } from '..';
 
-export interface TempProperties {
+export interface TempProperty {
     guiDef: IHasProperty;
     propDef: PropertyDefinition;
     values: ReadValue[];
@@ -47,7 +47,7 @@ export class PropertiesViewComponent implements OnInit {
 
     FileRepresentation = FileRepresentation;
 
-    propArray: TempProperties[] = [];
+    propArray: TempProperty[] = [];
 
     constructor(
         protected _router: Router) {
@@ -69,7 +69,7 @@ export class PropertiesViewComponent implements OnInit {
                 this.resource.entityInfo.properties[index] instanceof ResourcePropertyDefinition &&
                 !this.FileRepresentation.list.includes(index)) {
 
-                const tempProp: TempProperties = {
+                const tempProp: TempProperty = {
                     guiDef: hasProp,
                     propDef: this.resource.entityInfo.properties[index],
                     values: this.resource.properties[index]

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.ts
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.ts
@@ -1,10 +1,11 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { Constants, IHasProperty, IResourceClassAndPropertyDefinitions, ReadResource, ReadValue, ResourcePropertyDefinition } from '@knora/api';
-// import { KnoraConstants } from '@knora/core';
+import { IHasProperty, ReadResource, ReadValue, ResourcePropertyDefinition } from '@knora/api';
 import { PropertyDefinition } from '@knora/api/src/models/v2/ontologies/property-definition';
 
-export interface TempProp {
+import { FileRepresentation } from '..';
+
+export interface TempProperties {
     guiDef: IHasProperty;
     propDef: PropertyDefinition;
     values: ReadValue[];
@@ -21,79 +22,37 @@ export interface TempProp {
 })
 export class PropertiesViewComponent implements OnInit {
 
-    loading: boolean = true;
-
-    KnoraConstants = Constants;
-
-    propArray: TempProp[] = [];
-
-    // TODO: make a list of file value iri definitions, to filter in list of properties
-    HasFileRepresentation: string[] = [
-        Constants.KnoraApiV2 + Constants.Delimiter + 'hasStillImageFileValue'
-    ];
-
-    // @Input() guiOrder?: GuiOrder;
-
     @Input() resource: ReadResource;
 
-    // @Input() classType: string;
+    @Input() showAll?: boolean = false;
 
-    // @Input() entityInfo: IResourceClassAndPropertyDefinitions;
+    loading: boolean = true;
 
-    // @Input() properties: {
-    //     [index: string]: ReadValue[];
-    // };
+    FileRepresentation = FileRepresentation;
 
-    @Input() annotations?: ReadResource[];
-    @Input() incomingLinks?: ReadResource[];
-
-    // @Output() routeChanged: EventEmitter<string> = new EventEmitter<string>();
+    propArray: TempProperties[] = [];
 
     constructor(
-
         protected _router: Router) {
-
     }
 
     ngOnInit() {
+        this.loading = true;
 
-
-        // HACK (until gui order is ready): convert properties object into array
-
-
-        // console.log(Object.keys(this.properties));
-
-        // this.propArray = Object.keys(this.properties);
-
+        // get list of all properties
         const hasProps: IHasProperty[] = this.resource.entityInfo.classes[this.resource.type].propertiesList;
-
-        console.log('hasProps', hasProps);
-
-        // this.propArray = Object.keys(this.properties).map(function (index) {
-        //     console.log('index', index);
-
-        //     const hasProp = hasProps.find(i => i.propertyIndex === index);
-
-
-
-
-
-
-
-        //     // console.log(this.entityInfo.classes[this.classType].propertiesList.find((item: IHasProperty) => item.propertyIndex === index));
-        //     return hasProp;
-        // });
-
-        // console.log(this.propArray);
 
         let i = 0;
         for (const hasProp of hasProps) {
 
-
             const index = hasProp.propertyIndex;
 
-            if (this.resource.entityInfo.properties[index] && this.resource.entityInfo.properties[index] instanceof ResourcePropertyDefinition) {
-                const tempProp: TempProp = {
+            // filter all properties by type ResourcePropertyDefinition and exclude hasFileRepresentations
+            if (this.resource.entityInfo.properties[index] &&
+                this.resource.entityInfo.properties[index] instanceof ResourcePropertyDefinition &&
+                !this.FileRepresentation.list.includes(index)) {
+
+                const tempProp: TempProperties = {
                     guiDef: hasProp,
                     propDef: this.resource.entityInfo.properties[index],
                     values: this.resource.properties[index]
@@ -102,47 +61,18 @@ export class PropertiesViewComponent implements OnInit {
                 this.propArray.push(tempProp);
             }
 
-
-
-            // console.log(Object.values());
-
-            // entitiy info classes propertylist
-            // console.log(this.entityInfo.classes[this.classType].propertiesList.find(i => i.propertyIndex === pid));
-
-
-            //     console.log(prop);
-            //     //this.entityInfo.classes[0].propertiesList[prop]);
             i++;
         }
 
-        console.log(this.propArray);
-
-
-        // console.log(this.entityInfo.classes[this.classType].propertiesList);
-
-        /*
-        this.propArray = Object.keys(this.properties).map(function (index) {
-            console.log(index, this.properties[index]);
-            const prop = this.resource.properties[index];
-            console.log(prop);
-            return prop;
-        });
+        // sort properties by guiOrder
+        this.propArray.sort((a, b) => (a.guiDef.guiOrder > b.guiDef.guiOrder) ? 1 : -1);
 
         console.log(this.propArray);
 
-        /*
-        if (this.resource.properties) {
-            // set props in the correct gui order
+        this.loading = false;
 
-
-            this.propArray = Object.keys(this.resource.properties).map(function (index) {
-                const prop = this.resource.properties[index];
-                console.log(prop);
-                return prop;
-            });
-            console.log(this.propArray);
-        } */
     }
+
     /**
      * Navigate to the incoming resource view.
      *

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.ts
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.ts
@@ -1,7 +1,14 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { IResourceClassAndPropertyDefinitions, ReadResource, ReadValue, ClassDefinition, IHasProperty } from '@knora/api';
-import { GuiOrder, KnoraConstants } from '@knora/core';
+import { Constants, IHasProperty, IResourceClassAndPropertyDefinitions, ReadResource, ReadValue, ResourcePropertyDefinition } from '@knora/api';
+// import { KnoraConstants } from '@knora/core';
+import { PropertyDefinition } from '@knora/api/src/models/v2/ontologies/property-definition';
+
+export interface TempProp {
+    guiDef: IHasProperty;
+    propDef: PropertyDefinition;
+    values: ReadValue[];
+}
 
 /**
  * Shows all metadata (properties) in the resource viewer
@@ -16,30 +23,39 @@ export class PropertiesViewComponent implements OnInit {
 
     loading: boolean = true;
 
-    KnoraConstants = KnoraConstants;
+    KnoraConstants = Constants;
+
+    propArray: TempProp[] = [];
 
     // @Input() guiOrder?: GuiOrder;
 
-    @Input() classType: string;
+    @Input() resource: ReadResource;
 
-    @Input() entityInfo: IResourceClassAndPropertyDefinitions;
 
-    @Input() properties: {
-        [index: string]: ReadValue[];
-    };
+
+
+    // @Input() classType: string;
+
+    // @Input() entityInfo: IResourceClassAndPropertyDefinitions;
+
+    // @Input() properties: {
+    //     [index: string]: ReadValue[];
+    // };
 
     @Input() annotations?: ReadResource[];
     @Input() incomingLinks?: ReadResource[];
 
-    propArray: any[] = [];
-
     // @Output() routeChanged: EventEmitter<string> = new EventEmitter<string>();
 
-    constructor(protected _router: Router) {
+    constructor(
+
+        protected _router: Router) {
 
     }
 
     ngOnInit() {
+
+
         // HACK (until gui order is ready): convert properties object into array
 
 
@@ -47,25 +63,44 @@ export class PropertiesViewComponent implements OnInit {
 
         // this.propArray = Object.keys(this.properties);
 
-        const hasProps: IHasProperty[] = this.entityInfo.classes[this.classType].propertiesList;
+        const hasProps: IHasProperty[] = this.resource.entityInfo.classes[this.resource.type].propertiesList;
 
-        // console.log('hasProps', hasProps);
+        console.log('hasProps', hasProps);
 
-        this.propArray = Object.keys(this.properties).map(function (index) {
-            console.log('index', index);
+        // this.propArray = Object.keys(this.properties).map(function (index) {
+        //     console.log('index', index);
 
-            const hasProp = hasProps.find(i => i.propertyIndex === index);
+        //     const hasProp = hasProps.find(i => i.propertyIndex === index);
 
 
 
-            // console.log(this.entityInfo.classes[this.classType].propertiesList.find((item: IHasProperty) => item.propertyIndex === index));
-            return hasProp;
-        });
 
-        console.log(this.propArray);
 
-        for (const pid of Object.keys(this.properties)) {
-            // console.log('pid', pid);
+
+
+        //     // console.log(this.entityInfo.classes[this.classType].propertiesList.find((item: IHasProperty) => item.propertyIndex === index));
+        //     return hasProp;
+        // });
+
+        // console.log(this.propArray);
+
+        let i = 0;
+        for (const hasProp of hasProps) {
+
+
+            const index = hasProp.propertyIndex;
+
+            if (this.resource.entityInfo.properties[index] && this.resource.entityInfo.properties[index] instanceof ResourcePropertyDefinition) {
+                const tempProp: TempProp = {
+                    guiDef: hasProp,
+                    propDef: this.resource.entityInfo.properties[index],
+                    values: this.resource.properties[index]
+                };
+
+                this.propArray.push(tempProp);
+            }
+
+
 
             // console.log(Object.values());
 
@@ -75,7 +110,10 @@ export class PropertiesViewComponent implements OnInit {
 
             //     console.log(prop);
             //     //this.entityInfo.classes[0].propertiesList[prop]);
+            i++;
         }
+
+        console.log(this.propArray);
 
 
         // console.log(this.entityInfo.classes[this.classType].propertiesList);

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.ts
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.ts
@@ -1,15 +1,8 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { IHasProperty, ReadResource, ReadValue, ResourcePropertyDefinition } from '@knora/api';
-import { PropertyDefinition } from '@knora/api/src/models/v2/ontologies/property-definition';
+import { ReadResource } from '@knora/api';
 
-import { FileRepresentation } from '..';
-
-export interface TempProperty {
-    guiDef: IHasProperty;
-    propDef: PropertyDefinition;
-    values: ReadValue[];
-}
+import { TempProperty } from '..';
 
 /**
  * Shows all metadata (properties) in the resource viewer
@@ -23,11 +16,11 @@ export interface TempProperty {
 export class PropertiesViewComponent implements OnInit {
 
     /**
-     * Resource object
+     * Array of property object with ontology class prop def, list of properties and corresponding values
      *
-     * @param  {ReadResource} resource
+     * @param  {TempProperty} propArray
      */
-    @Input() resource: ReadResource;
+    @Input() propArray: TempProperty;
 
     /**
      * Show all properties, even they don't have a value.
@@ -43,50 +36,13 @@ export class PropertiesViewComponent implements OnInit {
      */
     @Input() toolbar?: boolean = false;
 
-    loading: boolean = true;
-
-    FileRepresentation = FileRepresentation;
-
-    propArray: TempProperty[] = [];
+    loading: boolean = false;
 
     constructor(
         protected _router: Router) {
     }
 
     ngOnInit() {
-        this.loading = true;
-
-        // get list of all properties
-        const hasProps: IHasProperty[] = this.resource.entityInfo.classes[this.resource.type].propertiesList;
-
-        let i = 0;
-        for (const hasProp of hasProps) {
-
-            const index = hasProp.propertyIndex;
-
-            // filter all properties by type ResourcePropertyDefinition and exclude hasFileRepresentations
-            if (this.resource.entityInfo.properties[index] &&
-                this.resource.entityInfo.properties[index] instanceof ResourcePropertyDefinition &&
-                !this.FileRepresentation.list.includes(index)) {
-
-                const tempProp: TempProperty = {
-                    guiDef: hasProp,
-                    propDef: this.resource.entityInfo.properties[index],
-                    values: this.resource.properties[index]
-                };
-
-                this.propArray.push(tempProp);
-            }
-
-            i++;
-        }
-
-        // sort properties by guiOrder
-        this.propArray.sort((a, b) => (a.guiDef.guiOrder > b.guiDef.guiOrder) ? 1 : -1);
-
-        console.log(this.propArray);
-
-        this.loading = false;
 
     }
 
@@ -103,9 +59,5 @@ export class PropertiesViewComponent implements OnInit {
 
     }
 
-
-    toggleProps(show: boolean) {
-        this.allProps = !this.allProps;
-    }
 
 }

--- a/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.ts
+++ b/projects/knora/viewer/src/lib/view/properties-view/properties-view.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { IResourceClassAndPropertyDefinitions, ReadValue } from '@knora/api';
-import { GuiOrder, KnoraConstants, ReadResource } from '@knora/core';
+import { IResourceClassAndPropertyDefinitions, ReadResource, ReadValue, ClassDefinition, IHasProperty } from '@knora/api';
+import { GuiOrder, KnoraConstants } from '@knora/core';
 
 /**
  * Shows all metadata (properties) in the resource viewer
@@ -14,13 +14,16 @@ import { GuiOrder, KnoraConstants, ReadResource } from '@knora/core';
 })
 export class PropertiesViewComponent implements OnInit {
 
-    loading: boolean = false;
+    loading: boolean = true;
 
     KnoraConstants = KnoraConstants;
 
-    @Input() guiOrder?: GuiOrder;
+    // @Input() guiOrder?: GuiOrder;
+
+    @Input() classType: string;
 
     @Input() entityInfo: IResourceClassAndPropertyDefinitions;
+
     @Input() properties: {
         [index: string]: ReadValue[];
     };
@@ -28,7 +31,7 @@ export class PropertiesViewComponent implements OnInit {
     @Input() annotations?: ReadResource[];
     @Input() incomingLinks?: ReadResource[];
 
-    propArray: any = [];
+    propArray: any[] = [];
 
     // @Output() routeChanged: EventEmitter<string> = new EventEmitter<string>();
 
@@ -38,13 +41,67 @@ export class PropertiesViewComponent implements OnInit {
 
     ngOnInit() {
         // HACK (until gui order is ready): convert properties object into array
-        if (this.properties) {
-            this.propArray = Object.keys(this.properties).map(function (index) {
-                const prop = this.properties[index];
+
+
+        // console.log(Object.keys(this.properties));
+
+        // this.propArray = Object.keys(this.properties);
+
+        const hasProps: IHasProperty[] = this.entityInfo.classes[this.classType].propertiesList;
+
+        // console.log('hasProps', hasProps);
+
+        this.propArray = Object.keys(this.properties).map(function (index) {
+            console.log('index', index);
+
+            const hasProp = hasProps.find(i => i.propertyIndex === index);
+
+
+
+            // console.log(this.entityInfo.classes[this.classType].propertiesList.find((item: IHasProperty) => item.propertyIndex === index));
+            return hasProp;
+        });
+
+        console.log(this.propArray);
+
+        for (const pid of Object.keys(this.properties)) {
+            // console.log('pid', pid);
+
+            // console.log(Object.values());
+
+            // entitiy info classes propertylist
+            // console.log(this.entityInfo.classes[this.classType].propertiesList.find(i => i.propertyIndex === pid));
+
+
+            //     console.log(prop);
+            //     //this.entityInfo.classes[0].propertiesList[prop]);
+        }
+
+
+        // console.log(this.entityInfo.classes[this.classType].propertiesList);
+
+        /*
+        this.propArray = Object.keys(this.properties).map(function (index) {
+            console.log(index, this.properties[index]);
+            const prop = this.resource.properties[index];
+            console.log(prop);
+            return prop;
+        });
+
+        console.log(this.propArray);
+
+        /*
+        if (this.resource.properties) {
+            // set props in the correct gui order
+
+
+            this.propArray = Object.keys(this.resource.properties).map(function (index) {
+                const prop = this.resource.properties[index];
+                console.log(prop);
                 return prop;
             });
             console.log(this.propArray);
-        }
+        } */
     }
     /**
      * Navigate to the incoming resource view.

--- a/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.html
+++ b/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.html
@@ -38,12 +38,9 @@
                 <!-- first tab for the main resource e.g. book -->
                 <mat-tab [label]="resource.entityInfo?.classes[resource.type].label">
                     <!-- header with project / ontology / resource class info / ark url -->
-                    <!-- TODO: move to the properties view -->
-                    <kui-properties-toolbar *ngIf="toolbar" [projectiri]="resource.attachedToProject"
-                                            [showAllProps]="showAllProps" (toggleProps)="toggleProps($event)">
-                    </kui-properties-toolbar>
 
-                    <kui-properties-view [resource]="resource" [showAll]="showAllProps"></kui-properties-view>
+                    <kui-properties-view [resource]="resource" [toolbar]="toolbar" [allProps]="allProps">
+                    </kui-properties-view>
 
 
                     <!-- TODO: [guiOrder]="guiOrder" /  [ontologyInfo]="resource.entityInfo" is missing? couldn't find yet -->

--- a/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.html
+++ b/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.html
@@ -4,9 +4,66 @@
     <div *ngIf="!loading && resource">
 
         <div class="resource">
+            <!-- media -->
 
-            <!-- 0) Title first? -->
-            <!--             <mat-list>
+            <!-- tabs with header and properties -->
+            <mat-tab-group animationDuration="0ms" class="full-width data">
+                <!-- first tab for the main resource e.g. book -->
+                <mat-tab [label]="resource.entityInfo?.classes[resource.type].label">
+
+                    <kui-properties-view [properties]="resource?.properties" [entityInfo]="resource?.entityInfo"
+                                         [classType]="resource.type">
+                    </kui-properties-view>
+
+
+                    <!-- TODO: [guiOrder]="guiOrder" /  [ontologyInfo]="resource.entityInfo" is missing? couldn't find yet -->
+                    <!-- <kui-properties-view [properties]="resource?.properties" [entityInfo]="resource?.entityInfo"
+                                             [incomingLinks]="resource?.incomingReferences">
+                        </kui-properties-view> -->
+                </mat-tab>
+
+                <!-- TODO: second tab for a "part-of"-resource e.g. book page -->
+                <!-- Couldn't find an incomingFileRepresentation in the new ReadResource from knora-api-js-lib -->
+                <!-- <mat-tab *ngIf="resource.incomingReferences.length > 0 && currentResource"
+                        [label]="sequence.ontologyInformation.getLabelForResourceClass(currentResource.type)">
+
+                </mat-tab> -->
+
+                <!-- TODO: third tab for a "region"-resource e.g. region on book page -->
+                <!-- <mat-tag></mat-tag> -->
+
+
+
+                <!-- TODO: incoming file representations are missing; or could not find it yet -->
+
+                <!--
+                    <mat-tab *ngIf="resource.incomingFileRepresentations.length > 0 && currentResource"
+                             [label]="sequence.ontologyInformation.getLabelForResourceClass(currentResource.type)">
+                        <kui-properties-view [properties]="currentResource?.properties"
+                                             [guiOrder]="sequence.ontologyInformation.getResourceClasses()[currentResource.type].guiOrder"
+                                             [ontologyInfo]="sequence.ontologyInformation">
+                        </kui-properties-view>
+                        <!--
+                        <kui-properties-view [properties]="resource.incomingFileRepresentations[0].resource.properties"
+                                             [guiOrder]="sequence.ontologyInformation.getResourceClasses()[resource.incomingFileRepresentations[0].type].guiOrder"
+                                             [ontologyInfo]="sequence.ontologyInformation"
+                                             [incomingLinks]="resource.incomingFileRepresentations[0].incomingLinks">
+                        </kui-properties-view>
+                    -->
+                <!-- </mat-tab> -->
+                -->
+                <!-- TODO: third tab for a "region"-resource -->
+            </mat-tab-group>
+
+
+        </div>
+    </div>
+</div>
+
+
+
+<!-- 0) Title first? -->
+<!--             <mat-list>
 
                 <h3 class="mat-subheader">
                     {{sequence.ontologyInformation.getLabelForResourceClass(resource.type)}}
@@ -18,16 +75,16 @@
 
             </mat-list> -->
 
-            <!-- 1) show fileRepresentation first-->
+<!-- 1) show fileRepresentation first-->
 
-            <!-- show file representation -->
-            <!-- <div *ngIf="resource.fileRepresentationsToDisplay?.stillImage && resource.fileRepresentationsToDisplay?.stillImage.length > 0"
+<!-- show file representation -->
+<!-- <div *ngIf="resource.fileRepresentationsToDisplay?.stillImage && resource.fileRepresentationsToDisplay?.stillImage.length > 0"
                  class="media">
                 <kui-still-image #kuiStillImage class="osd-viewer"
                                  [images]="resource.fileRepresentationsToDisplay.stillImage">
                 </kui-still-image>
             </div> -->
-            <!--
+<!--
                 <div [ngSwitch]="resource.fileRepresentationsToDisplay[0].type" class="media">
                     <div *ngSwitchCase="KnoraConstants.StillImageFileValue">
                         <!-- TODO: fix: this shows only the first image, not all stillImages from fileRepresentationsToDisplay --
@@ -48,20 +105,20 @@
 
 
 
-            <!--
+<!--
             <div *ngFor="let prop of resource.properties | kuiKey">
                 <div [ngSwitch]="prop.key">
                     <!-- <p>{{prop.key}}</p> -->
 
-            <!-- <div *ngSwitchCase="KnoraConstants.hasStillImageFileValue" class="media"> -->
-            <!-- if the property is of type stillImageFileValue, show the image with osd viewer from @knora/viewer TODO: the fileValue will be part of an own resource property -->
+<!-- <div *ngSwitchCase="KnoraConstants.hasStillImageFileValue" class="media"> -->
+<!-- if the property is of type stillImageFileValue, show the image with osd viewer from @knora/viewer TODO: the fileValue will be part of an own resource property -->
 
 
-            <!-- </div> -->
+<!-- </div> -->
 
 
-            <!-- TODO: switch through all other media type -->
-            <!--
+<!-- TODO: switch through all other media type -->
+<!--
                     <kui-moving-image></kui-moving-image>
                     <kui-audio></kui-audio>
                     <kui-ddd></kui-ddd>
@@ -75,55 +132,26 @@
                     <kui-region></kui-region>
                     <kui-text></kui-text>
                     -->
-            <!--
+<!--
                     <div *ngSwitchDefault>
                         <p>This media type ({{prop.key}}) is not yet implemented</p>
                     </div>
                 </div>
             </div>
             -->
-            <!-- 2) show properties, annotations (list of regions, sequences etc.), incomming resources (links, files) -->
-            <mat-tab-group animationDuration="0ms" class="full-width data">
-                <!-- first tab for the main resource e.g. book -->
-                <mat-tab [label]="resource.entityInfo?.classes[resource.type].label">
-                    <!-- TODO: [guiOrder]="guiOrder" /  [ontologyInfo]="resource.entityInfo" is missing? couldn't find yet -->
-                    <kui-properties-view [properties]="resource?.properties" [entityInfo]="resource?.entityInfo"
-                                         [incomingLinks]="resource?.incomingReferences">
-                    </kui-properties-view>
-                </mat-tab>
-                <!-- TODO: second tab for a "part-of"-resource e.g. book page -->
-
-                <!-- TODO: incoming file representations are missing; or could not find it yet -->
-
-                <!--
-                <mat-tab *ngIf="resource.incomingFileRepresentations.length > 0 && currentResource"
-                         [label]="sequence.ontologyInformation.getLabelForResourceClass(currentResource.type)">
-                    <kui-properties-view [properties]="currentResource?.properties"
-                                         [guiOrder]="sequence.ontologyInformation.getResourceClasses()[currentResource.type].guiOrder"
-                                         [ontologyInfo]="sequence.ontologyInformation">
-                    </kui-properties-view>
-                    <!--
-                    <kui-properties-view [properties]="resource.incomingFileRepresentations[0].resource.properties"
-                                         [guiOrder]="sequence.ontologyInformation.getResourceClasses()[resource.incomingFileRepresentations[0].type].guiOrder"
-                                         [ontologyInfo]="sequence.ontologyInformation"
-                                         [incomingLinks]="resource.incomingFileRepresentations[0].incomingLinks">
-                    </kui-properties-view>
-                -->
-                <!-- </mat-tab> -->
-                -->
-                <!-- TODO: third tab for a "region"-resource -->
-            </mat-tab-group>
+<!-- 2) show properties, annotations (list of regions, sequences etc.), incomming resources (links, files) -->
 
 
 
 
-            <!-- in case of more than one resource -->
-            <!-- <mat-divider *ngIf="!last"></mat-divider> -->
 
-        </div>
+<!-- in case of more than one resource -->
+<!-- <mat-divider *ngIf="!last"></mat-divider> -->
+
+<!-- </div>
 
     </div>
-</div>
+</div> -->
 
 <!-- in case of an error show the following message -->
 <div class="resource-view error content large middle" *ngIf="error">

--- a/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.html
+++ b/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.html
@@ -11,8 +11,7 @@
                 <!-- first tab for the main resource e.g. book -->
                 <mat-tab [label]="resource.entityInfo?.classes[resource.type].label">
 
-                    <kui-properties-view [properties]="resource?.properties" [entityInfo]="resource?.entityInfo"
-                                         [classType]="resource.type">
+                    <kui-properties-view [resource]="resource">
                     </kui-properties-view>
 
 

--- a/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.html
+++ b/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.html
@@ -10,9 +10,11 @@
             <mat-tab-group animationDuration="0ms" class="full-width data">
                 <!-- first tab for the main resource e.g. book -->
                 <mat-tab [label]="resource.entityInfo?.classes[resource.type].label">
+                    <!-- header with project / ontology / resource class info / ark url -->
+                    <kui-properties-toolbar *ngIf="toolbar" [projectiri]="resource.attachedToProject">
+                    </kui-properties-toolbar>
 
-                    <kui-properties-view [resource]="resource">
-                    </kui-properties-view>
+                    <kui-properties-view [resource]="resource"></kui-properties-view>
 
 
                     <!-- TODO: [guiOrder]="guiOrder" /  [ontologyInfo]="resource.entityInfo" is missing? couldn't find yet -->

--- a/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.html
+++ b/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.html
@@ -4,17 +4,46 @@
     <div *ngIf="!loading && resource">
 
         <div class="resource">
-            <!-- media -->
+            <!-- media: show file representation -->
+            <!-- <div *ngIf="HasFileRepresentation">
+                <div [ngSwitch]="resource.fileRepresentationsToDisplay[0].type" class="media"></div>
+            </div> -->
+            <!-- <div *ngIf="resource.fileRepresentationsToDisplay?.stillImage && resource.fileRepresentationsToDisplay?.stillImage.length > 0"
+                 class="media">
+                <kui-still-image #kuiStillImage class="osd-viewer"
+                                 [images]="resource.fileRepresentationsToDisplay.stillImage">
+                </kui-still-image>
+            </div> -->
+            <!--
+                <div [ngSwitch]="resource.fileRepresentationsToDisplay[0].type" class="media">
+                    <div *ngSwitchCase="KnoraConstants.StillImageFileValue">
+                        <!-- TODO: fix: this shows only the first image, not all stillImages from fileRepresentationsToDisplay --
+
+                        <!-- [imageCaption]="sequence.ontologyInformation.getLabelForProperty(prop.key)" --
+                    </div>
+
+
+                    <div *ngSwitchCase="KnoraConstants.hasMovingImageFileValue" class="media">
+                        <kui-moving-image></kui-moving-image>
+                    </div>
+
+                    <div *ngSwitchDefault>
+                        <p>This media type {{resource.fileRepresentationsToDisplay[0].type}} is not yet implemented</p>
+                    </div>
+                </div>
+                -->
 
             <!-- tabs with header and properties -->
             <mat-tab-group animationDuration="0ms" class="full-width data">
                 <!-- first tab for the main resource e.g. book -->
                 <mat-tab [label]="resource.entityInfo?.classes[resource.type].label">
                     <!-- header with project / ontology / resource class info / ark url -->
-                    <kui-properties-toolbar *ngIf="toolbar" [projectiri]="resource.attachedToProject">
+                    <!-- TODO: move to the properties view -->
+                    <kui-properties-toolbar *ngIf="toolbar" [projectiri]="resource.attachedToProject"
+                                            [showAllProps]="showAllProps" (toggleProps)="toggleProps($event)">
                     </kui-properties-toolbar>
 
-                    <kui-properties-view [resource]="resource"></kui-properties-view>
+                    <kui-properties-view [resource]="resource" [showAll]="showAllProps"></kui-properties-view>
 
 
                     <!-- TODO: [guiOrder]="guiOrder" /  [ontologyInfo]="resource.entityInfo" is missing? couldn't find yet -->
@@ -44,7 +73,7 @@
                                              [guiOrder]="sequence.ontologyInformation.getResourceClasses()[currentResource.type].guiOrder"
                                              [ontologyInfo]="sequence.ontologyInformation">
                         </kui-properties-view>
-                        <!--
+
                         <kui-properties-view [properties]="resource.incomingFileRepresentations[0].resource.properties"
                                              [guiOrder]="sequence.ontologyInformation.getResourceClasses()[resource.incomingFileRepresentations[0].type].guiOrder"
                                              [ontologyInfo]="sequence.ontologyInformation"
@@ -52,7 +81,7 @@
                         </kui-properties-view>
                     -->
                 <!-- </mat-tab> -->
-                -->
+
                 <!-- TODO: third tab for a "region"-resource -->
             </mat-tab-group>
 

--- a/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.html
+++ b/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.html
@@ -1,186 +1,61 @@
 <kui-progress-indicator *ngIf="loading"></kui-progress-indicator>
-<div class="resource-view" *ngIf="!error">
+<div class="resource-view" *ngIf="!error && !loading && resource">
 
-    <div *ngIf="!loading && resource">
+    <!-- media: show file representation -->
+    <div *ngIf="fileRepresentation">
+        <div [ngSwitch]="fileRepresentation[0].type" class="media">
 
-        <div class="resource">
-            <!-- media: show file representation -->
-            <div *ngIf="fileRepresentation">
-                <div [ngSwitch]="fileRepresentation[0].type" class="media">
+            <kui-still-image *ngSwitchCase="Constants.StillImageFileValue" #kuiStillImage class="osd-viewer"
+                             [images]="fileRepresentation">
+            </kui-still-image>
 
-                    <kui-still-image *ngSwitchCase="Constants.StillImageFileValue" #kuiStillImage class="osd-viewer"
-                                     [images]="fileRepresentation">
-                    </kui-still-image>
+            <!-- TODO: switch through all other media type --
+            <kui-moving-image></kui-moving-image>
+            <kui-audio></kui-audio>
+            <kui-ddd></kui-ddd>
+            <kui-document></kui-document>
 
-                    <kui-message *ngSwitchDefault [medium]="true"
-                                 [message]="{status: 501, statusMsg: 'Not yet implemented', statusText: fileRepresentation[0].type + ' is not yet implemented'}">
-                    </kui-message>
+            <kui-collection></kui-collection>
 
-                </div>
-            </div>
+            <kui-annotation></kui-annotation>
+            <kui-link-obj></kui-link-obj>
+            <kui-object></kui-object>
+            <kui-region></kui-region>
+            <kui-text></kui-text>
+            -->
 
-            <!--  -->
-            <!--
-                <div [ngSwitch]="resource.fileRepresentationsToDisplay[0].type" class="media">
-                    <div *ngSwitchCase="KnoraConstants.StillImageFileValue">
-                        <!-- TODO: fix: this shows only the first image, not all stillImages from fileRepresentationsToDisplay --
-
-                        <!-- [imageCaption]="sequence.ontologyInformation.getLabelForProperty(prop.key)" --
-                    </div>
-
-
-                    <div *ngSwitchCase="KnoraConstants.hasMovingImageFileValue" class="media">
-                        <kui-moving-image></kui-moving-image>
-                    </div>
-
-
-                </div>
-                -->
-
-            <!-- tabs with header and properties -->
-            <mat-tab-group animationDuration="0ms" class="full-width data">
-                <!-- first tab for the main resource e.g. book -->
-                <mat-tab [label]="resource.entityInfo?.classes[resource.type].label">
-                    <!-- header with project / ontology / resource class info / ark url -->
-                    <kui-properties-toolbar *ngIf="toolbar" [projectiri]="resource.attachedToProject"
-                                            [allProps]="allProps" (toggleProps)="toggleProps($event)">
-                    </kui-properties-toolbar>
-
-                    <kui-properties-view [propArray]="propArray" [toolbar]="toolbar" [allProps]="allProps">
-                    </kui-properties-view>
-
-                </mat-tab>
-
-                <!-- TODO: second tab for a "part-of"-resource e.g. book page -->
-                <!-- Couldn't find an incomingFileRepresentation in the new ReadResource from knora-api-js-lib -->
-                <mat-tab *ngIf="resource.incomingReferences.length > 0 && currentResource"
-                         [label]="sequence.ontologyInformation.getLabelForResourceClass(currentResource.type)">
-
-                </mat-tab>
-
-                <!-- TODO: third tab for a "region"-resource e.g. region on book page -->
-                <!-- <mat-tag></mat-tag> -->
-
-
-
-                <!-- TODO: incoming file representations are missing; or could not find it yet -->
-
-                <!--
-                    <mat-tab *ngIf="resource.incomingFileRepresentations.length > 0 && currentResource"
-                             [label]="sequence.ontologyInformation.getLabelForResourceClass(currentResource.type)">
-                        <kui-properties-view [properties]="currentResource?.properties"
-                                             [guiOrder]="sequence.ontologyInformation.getResourceClasses()[currentResource.type].guiOrder"
-                                             [ontologyInfo]="sequence.ontologyInformation">
-                        </kui-properties-view>
-
-                        <kui-properties-view [properties]="resource.incomingFileRepresentations[0].resource.properties"
-                                             [guiOrder]="sequence.ontologyInformation.getResourceClasses()[resource.incomingFileRepresentations[0].type].guiOrder"
-                                             [ontologyInfo]="sequence.ontologyInformation"
-                                             [incomingLinks]="resource.incomingFileRepresentations[0].incomingLinks">
-                        </kui-properties-view>
-                    -->
-                <!-- </mat-tab> -->
-
-                <!-- TODO: third tab for a "region"-resource -->
-            </mat-tab-group>
-
+            <kui-message *ngSwitchDefault [medium]="true"
+                         [message]="{status: 501, statusMsg: 'Not yet implemented', statusText: fileRepresentation[0].type + ' is not yet implemented'}">
+            </kui-message>
 
         </div>
     </div>
+
+    <!-- properties / meta data -->
+    <!-- tabs with header toolbar and properties -->
+    <mat-tab-group animationDuration="0ms" class="full-width data">
+        <!-- first tab for the main resource e.g. book -->
+        <mat-tab [label]="resource.entityInfo?.classes[resource.type].label">
+            <!-- header with project / ontology / resource class info / ark url -->
+            <kui-properties-toolbar *ngIf="toolbar" [projectiri]="resource.attachedToProject" [allProps]="allProps"
+                                    (toggleProps)="toggleProps($event)">
+            </kui-properties-toolbar>
+
+            <kui-properties-view [propArray]="propArray" [toolbar]="toolbar" [allProps]="allProps">
+            </kui-properties-view>
+
+        </mat-tab>
+
+        <!-- TODO: second tab for a "part-of"-resource e.g. book page -->
+        <!-- TODO: knora-api-js-lib: incoming file representations is empty; can't test it -->
+        <mat-tab *ngIf="resource.incomingReferences.length > 0 && activeResource"
+                 [label]="sequence.ontologyInformation.getLabelForResourceClass(activeResource.type)">
+        </mat-tab>
+
+        <!-- TODO: third tab for a "region"-resource e.g. region on book page -->
+        <!-- <mat-tab></mat-tab> -->
+    </mat-tab-group>
 </div>
-
-
-
-<!-- 0) Title first? -->
-<!--             <mat-list>
-
-                <h3 class="mat-subheader">
-                    {{sequence.ontologyInformation.getLabelForResourceClass(resource.type)}}
-                </h3>
-
-                <mat-list-item>
-                    <h2 class="mat-headline">{{resource.label}}</h2>
-                </mat-list-item>
-
-            </mat-list> -->
-
-<!-- 1) show fileRepresentation first-->
-
-<!-- show file representation -->
-<!-- <div *ngIf="resource.fileRepresentationsToDisplay?.stillImage && resource.fileRepresentationsToDisplay?.stillImage.length > 0"
-                 class="media">
-                <kui-still-image #kuiStillImage class="osd-viewer"
-                                 [images]="resource.fileRepresentationsToDisplay.stillImage">
-                </kui-still-image>
-            </div> -->
-<!--
-                <div [ngSwitch]="resource.fileRepresentationsToDisplay[0].type" class="media">
-                    <div *ngSwitchCase="KnoraConstants.StillImageFileValue">
-                        <!-- TODO: fix: this shows only the first image, not all stillImages from fileRepresentationsToDisplay --
-
-                        <!-- [imageCaption]="sequence.ontologyInformation.getLabelForProperty(prop.key)" --
-                    </div>
-
-
-                    <div *ngSwitchCase="KnoraConstants.hasMovingImageFileValue" class="media">
-                        <kui-moving-image></kui-moving-image>
-                    </div>
-
-                    <div *ngSwitchDefault>
-                        <p>This media type {{resource.fileRepresentationsToDisplay[0].type}} is not yet implemented</p>
-                    </div>
-                </div>
-                -->
-
-
-
-<!--
-            <div *ngFor="let prop of resource.properties | kuiKey">
-                <div [ngSwitch]="prop.key">
-                    <!-- <p>{{prop.key}}</p> -->
-
-<!-- <div *ngSwitchCase="KnoraConstants.hasStillImageFileValue" class="media"> -->
-<!-- if the property is of type stillImageFileValue, show the image with osd viewer from @knora/viewer TODO: the fileValue will be part of an own resource property -->
-
-
-<!-- </div> -->
-
-
-<!-- TODO: switch through all other media type -->
-<!--
-                    <kui-moving-image></kui-moving-image>
-                    <kui-audio></kui-audio>
-                    <kui-ddd></kui-ddd>
-                    <kui-document></kui-document>
-
-                    <kui-collection></kui-collection>
-
-                    <kui-annotation></kui-annotation>
-                    <kui-link-obj></kui-link-obj>
-                    <kui-object></kui-object>
-                    <kui-region></kui-region>
-                    <kui-text></kui-text>
-                    -->
-<!--
-                    <div *ngSwitchDefault>
-                        <p>This media type ({{prop.key}}) is not yet implemented</p>
-                    </div>
-                </div>
-            </div>
-            -->
-<!-- 2) show properties, annotations (list of regions, sequences etc.), incomming resources (links, files) -->
-
-
-
-
-
-<!-- in case of more than one resource -->
-<!-- <mat-divider *ngIf="!last"></mat-divider> -->
-
-<!-- </div>
-
-    </div>
-</div> -->
 
 <!-- in case of an error show the following message -->
 <div class="resource-view error content large middle" *ngIf="error">

--- a/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.html
+++ b/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.html
@@ -5,15 +5,21 @@
 
         <div class="resource">
             <!-- media: show file representation -->
-            <!-- <div *ngIf="HasFileRepresentation">
-                <div [ngSwitch]="resource.fileRepresentationsToDisplay[0].type" class="media"></div>
-            </div> -->
-            <!-- <div *ngIf="resource.fileRepresentationsToDisplay?.stillImage && resource.fileRepresentationsToDisplay?.stillImage.length > 0"
-                 class="media">
-                <kui-still-image #kuiStillImage class="osd-viewer"
-                                 [images]="resource.fileRepresentationsToDisplay.stillImage">
-                </kui-still-image>
-            </div> -->
+            <div *ngIf="fileRepresentation">
+                <div [ngSwitch]="fileRepresentation[0].type" class="media">
+
+                    <kui-still-image *ngSwitchCase="Constants.StillImageFileValue" #kuiStillImage class="osd-viewer"
+                                     [images]="fileRepresentation">
+                    </kui-still-image>
+
+                    <kui-message *ngSwitchDefault [medium]="true"
+                                 [message]="{status: 501, statusMsg: 'Not yet implemented', statusText: fileRepresentation[0].type + ' is not yet implemented'}">
+                    </kui-message>
+
+                </div>
+            </div>
+
+            <!--  -->
             <!--
                 <div [ngSwitch]="resource.fileRepresentationsToDisplay[0].type" class="media">
                     <div *ngSwitchCase="KnoraConstants.StillImageFileValue">
@@ -27,9 +33,7 @@
                         <kui-moving-image></kui-moving-image>
                     </div>
 
-                    <div *ngSwitchDefault>
-                        <p>This media type {{resource.fileRepresentationsToDisplay[0].type}} is not yet implemented</p>
-                    </div>
+
                 </div>
                 -->
 
@@ -38,23 +42,21 @@
                 <!-- first tab for the main resource e.g. book -->
                 <mat-tab [label]="resource.entityInfo?.classes[resource.type].label">
                     <!-- header with project / ontology / resource class info / ark url -->
+                    <kui-properties-toolbar *ngIf="toolbar" [projectiri]="resource.attachedToProject"
+                                            [allProps]="allProps" (toggleProps)="toggleProps($event)">
+                    </kui-properties-toolbar>
 
-                    <kui-properties-view [resource]="resource" [toolbar]="toolbar" [allProps]="allProps">
+                    <kui-properties-view [propArray]="propArray" [toolbar]="toolbar" [allProps]="allProps">
                     </kui-properties-view>
 
-
-                    <!-- TODO: [guiOrder]="guiOrder" /  [ontologyInfo]="resource.entityInfo" is missing? couldn't find yet -->
-                    <!-- <kui-properties-view [properties]="resource?.properties" [entityInfo]="resource?.entityInfo"
-                                             [incomingLinks]="resource?.incomingReferences">
-                        </kui-properties-view> -->
                 </mat-tab>
 
                 <!-- TODO: second tab for a "part-of"-resource e.g. book page -->
                 <!-- Couldn't find an incomingFileRepresentation in the new ReadResource from knora-api-js-lib -->
-                <!-- <mat-tab *ngIf="resource.incomingReferences.length > 0 && currentResource"
-                        [label]="sequence.ontologyInformation.getLabelForResourceClass(currentResource.type)">
+                <mat-tab *ngIf="resource.incomingReferences.length > 0 && currentResource"
+                         [label]="sequence.ontologyInformation.getLabelForResourceClass(currentResource.type)">
 
-                </mat-tab> -->
+                </mat-tab>
 
                 <!-- TODO: third tab for a "region"-resource e.g. region on book page -->
                 <!-- <mat-tag></mat-tag> -->

--- a/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.scss
+++ b/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.scss
@@ -1,5 +1,5 @@
-@import '../../assets/style/viewer';
-@import '../../assets/style/responsive';
+@import "../../assets/style/viewer";
+@import "../../assets/style/responsive";
 
 $width: 960px;
 
@@ -8,34 +8,25 @@ $width: 960px;
   margin: 0 auto;
   //   position: fixed;
 
-  .resource {
-    .media {
-      width: 800px;
-      height: 500px;
-      display: block;
-      margin: 0 auto;
-      // height: calc(#{$width} / (4 / 3));
-    }
+  .media {
+    height: 500px;
+    display: block;
+    margin: 0 auto;
+    // height: calc(#{$width} / (4 / 3));
+  }
 
-    .data {
-      //   grid-area: main;
-      min-height: 700px;
-      padding: 24px 36px;
+  .data {
+    //   grid-area: main;
+    min-height: 700px;
+    padding: 24px 0;
+  }
 
-      .headline {
-      }
+  .links {
+    //   grid-area: right;
+    //      grid-column: span 2;
+  }
 
-      .properties {
-      }
-    }
-
-    .links {
-      //   grid-area: right;
-      //      grid-column: span 2;
-    }
-
-    .footer {
-    }
+  .footer {
   }
 }
 
@@ -78,12 +69,12 @@ $width: 960px;
 */
 
 // mobile device: phone
-@media (max-width: map-get($grid-breakpoints, phone)) { 
+@media (max-width: map-get($grid-breakpoints, phone)) {
   .resource-view {
     .resource {
       .media {
         width: auto;
       }
     }
-  }  
+  }
 }

--- a/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.ts
+++ b/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.ts
@@ -111,7 +111,7 @@ export class ResourceViewComponent implements OnInit, OnChanges {
         this.knoraApiConnection.v2.res.getResource(id).subscribe(
             (response: ReadResource) => {
                 this.resource = response;
-                console.log(response);
+                // console.log(response);
 
                 // get list of all properties
                 const hasProps: IHasProperty[] = this.resource.entityInfo.classes[this.resource.type].propertiesList;
@@ -147,7 +147,7 @@ export class ResourceViewComponent implements OnInit, OnChanges {
                 // sort properties by guiOrder
                 this.propArray.sort((a, b) => (a.guiDef.guiOrder > b.guiDef.guiOrder) ? 1 : -1);
 
-                console.log(this.propArray);
+                // console.log(this.propArray);
 
                 // TODO: get info about file representation to load corresponding media view
 

--- a/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.ts
+++ b/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.ts
@@ -73,12 +73,15 @@ export class ResourceViewComponent implements OnInit, OnChanges {
 
         this.knoraApiConnection.v2.res.getResource(id).subscribe(
             (result: ReadResource) => {
-                console.log(result);
                 this.resource = result;
-                this.loading = false;
+                console.log(result);
+                setTimeout(() => {
+                    this.loading = false;
+                });
             },
             (error: ApiResponseError) => {
                 console.error(error);
+                this.loading = false;
             }
         );
 

--- a/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.ts
+++ b/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.ts
@@ -29,12 +29,23 @@ const jsonld = require('jsonld');
 export class ResourceViewComponent implements OnInit, OnChanges {
 
     /**
+     * Resource iri
+     *
      * @param {string} [iri] Resource iri
      */
     @Input() iri?: string;
 
     /**
-     * @param  {boolean} [toolbar] Show toolbar on top of properties if true.
+     * Show all properties, even they don't have a value.
+     *
+     * @param  {boolean} [allProps]
+     */
+    @Input() allProps?: boolean = false;
+
+    /**
+     * Show toolbar with project info and some action tools on top of properties if true.
+     *
+     * @param  {boolean} [toolbar]
      */
     @Input() toolbar?: boolean = false;
 
@@ -42,12 +53,11 @@ export class ResourceViewComponent implements OnInit, OnChanges {
     // if resource hasFileRepresentation: this would the iri
     hasFileRepresentation: string;
 
-    // TODO: needs probably general fileRepresentation container to watch
+    // TODO: needs probably general fileRepresentation container to watch on
     @ViewChild('kuiStillImage', { static: false }) kuiStillImage: StillImageComponent;
 
     resource: ReadResource;
 
-    showAllProps: boolean = false;
 
     sequence: ResourcesSequence;
 
@@ -159,12 +169,4 @@ export class ResourceViewComponent implements OnInit, OnChanges {
         // this.currentResource = this.sequence.resources[0].incomingFileRepresentations[index];
 
     }
-
-
-    toggleProps(show: boolean) {
-        this.showAllProps = !this.showAllProps;
-    }
-
-
-
 }

--- a/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.ts
+++ b/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.ts
@@ -65,6 +65,9 @@ export class ResourceViewComponent implements OnInit, OnChanges {
 
     resource: ReadResource;
 
+    // current resource displayed in case of compound object
+    activeResource: ReadResource;
+
     propArray: TempProperty[] = [];
 
     // does the resource has a file representation (media file)?
@@ -77,8 +80,6 @@ export class ResourceViewComponent implements OnInit, OnChanges {
     sequence: ResourcesSequence;
     guiOrder: GuiOrder[];
     error: KuiMessageData;
-    // current resource in case of compound object
-    currentResource: ReadResource;
 
     constructor(
         @Inject(KnoraApiConnectionToken) private knoraApiConnection: KnoraApiConnection,

--- a/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.ts
+++ b/projects/knora/viewer/src/lib/view/resource-view/resource-view.component.ts
@@ -25,6 +25,11 @@ export class ResourceViewComponent implements OnInit, OnChanges {
      */
     @Input() iri?: string;
 
+    /**
+     * @param  {boolean} [toolbar] Show toolbar on top of properties if true.
+     */
+    @Input() toolbar?: boolean = false;
+
     @ViewChild('kuiStillImage', { static: false }) kuiStillImage: StillImageComponent;
 
     resource: ReadResource;

--- a/projects/knora/viewer/src/lib/view/search-results/search-results.component.html
+++ b/projects/knora/viewer/src/lib/view/search-results/search-results.component.html
@@ -16,7 +16,7 @@
                     <mat-icon class="tab-icon">view_list</mat-icon>
                     List
                 </ng-template>
-                <kui-list-view [result]="result" [ontologyInfo]="ontologyInfo"></kui-list-view>
+                <kui-list-view [result]="result"></kui-list-view>
             </mat-tab>
 
             <!-- in caase of complexView: show tab to switch to grid view -->
@@ -25,7 +25,7 @@
                     <mat-icon class="tab-icon">view_module</mat-icon>
                     Grid
                 </ng-template>
-                <kui-grid-view [result]="result" [ontologyInfo]="ontologyInfo"></kui-grid-view>
+                <kui-grid-view [result]="result"></kui-grid-view>
             </mat-tab>
             <!-- not yet implemented! --
             <mat-tab>

--- a/projects/knora/viewer/src/lib/view/search-results/search-results.component.ts
+++ b/projects/knora/viewer/src/lib/view/search-results/search-results.component.ts
@@ -158,7 +158,10 @@ export class SearchResultsComponent implements OnInit, OnChanges {
                 if (this.offset === 0) {
                     // perform count query
                     this.knoraApiConnection.v2.search.doFulltextSearchCountQuery(this.searchQuery, searchParams).subscribe(
-                        this.showNumberOfAllResults,
+                        (response: CountQueryResponse) => {
+                            console.log(response);
+                            this.showNumberOfAllResults(response);
+                        },
                         (error: ApiResponseError) => {
                             this.errorMessage = error;
                         }
@@ -167,11 +170,17 @@ export class SearchResultsComponent implements OnInit, OnChanges {
 
                 // perform full text search
                 this.knoraApiConnection.v2.search.doFulltextSearch(this.searchQuery, this.offset, searchParams).subscribe(
-                    this.processSearchResults, // function pointer
+                    (response: ReadResource[]) => {
+                        // this.processSearchResults(response);
+                        console.log(response);
+                        this.result = response;
+                        this.loading = false;
+                    },
                     (error: ApiResponseError) => {
                         this.errorMessage = error;
                         console.log('error', error);
                         console.log('message', this.errorMessage);
+                        this.loading = false;
                     }
                 );
             }
@@ -181,16 +190,23 @@ export class SearchResultsComponent implements OnInit, OnChanges {
             // perform count query
             if (this.offset === 0) {
                 this.knoraApiConnection.v2.search.doExtendedSearchCountQuery(this.gravSearchQuery).subscribe(
-                    this.showNumberOfAllResults,
+                    (response: CountQueryResponse) => {
+                        this.showNumberOfAllResults(response);
+                    },
                     (error: ApiResponseError) => {
                         this.errorMessage = error;
                     }
                 );
             }
             this.knoraApiConnection.v2.search.doExtendedSearch(this.gravSearchQuery).subscribe(
-                this.processSearchResults, // function pointer
+                (response: ReadResource[]) => {
+                    // this.processSearchResults(response);
+                    this.result = response;
+                    this.loading = false;
+                },
                 (error: ApiResponseError) => {
                     this.errorMessage = error;
+                    this.loading = false;
                 }
             );
         } else {
@@ -212,7 +228,7 @@ export class SearchResultsComponent implements OnInit, OnChanges {
      *
      * @param {ReadResourcesSequence} searchResult the answer to a search request.
      */
-    private processSearchResults = (searchResult: ReadResource[]) => {
+    private processSearchResults(searchResult: ReadResource[]) {
         console.log(searchResult);
         // assign ontology information to a variable so it can be used in the component's template
         if (this.ontologyInfo === undefined) {
@@ -238,7 +254,7 @@ export class SearchResultsComponent implements OnInit, OnChanges {
      *
      * @param {ApiServiceResult} countQueryResult the response to a count query.
      */
-    private showNumberOfAllResults = (countQueryResult: CountQueryResponse) => {
+    private showNumberOfAllResults(countQueryResult: CountQueryResponse) {
         this.numberOfAllResults = countQueryResult.numberOfResults;
 
         if (this.numberOfAllResults > 0) {

--- a/projects/knora/viewer/src/lib/view/search-results/search-results.component.ts
+++ b/projects/knora/viewer/src/lib/view/search-results/search-results.component.ts
@@ -159,7 +159,7 @@ export class SearchResultsComponent implements OnInit, OnChanges {
                     // perform count query
                     this.knoraApiConnection.v2.search.doFulltextSearchCountQuery(this.searchQuery, searchParams).subscribe(
                         (response: CountQueryResponse) => {
-                            console.log(response);
+                            // console.log(response);
                             this.showNumberOfAllResults(response);
                         },
                         (error: ApiResponseError) => {
@@ -172,14 +172,13 @@ export class SearchResultsComponent implements OnInit, OnChanges {
                 this.knoraApiConnection.v2.search.doFulltextSearch(this.searchQuery, this.offset, searchParams).subscribe(
                     (response: ReadResource[]) => {
                         // this.processSearchResults(response);
-                        console.log(response);
+                        // console.log(response);
                         this.result = response;
                         this.loading = false;
                     },
                     (error: ApiResponseError) => {
                         this.errorMessage = error;
-                        console.log('error', error);
-                        console.log('message', this.errorMessage);
+                        console.error(error);
                         this.loading = false;
                     }
                 );
@@ -229,7 +228,7 @@ export class SearchResultsComponent implements OnInit, OnChanges {
      * @param {ReadResourcesSequence} searchResult the answer to a search request.
      */
     private processSearchResults(searchResult: ReadResource[]) {
-        console.log(searchResult);
+        // console.log(searchResult);
         // assign ontology information to a variable so it can be used in the component's template
         if (this.ontologyInfo === undefined) {
             // init ontology information

--- a/projects/knora/viewer/src/lib/viewer.module.ts
+++ b/projects/knora/viewer/src/lib/viewer.module.ts
@@ -59,6 +59,7 @@ import { PropertiesViewComponent } from './view/properties-view/properties-view.
 import { ResourceViewComponent } from './view/resource-view/resource-view.component';
 import { TableViewComponent } from './view/table-view/table-view.component';
 import { SearchResultsComponent } from './view/search-results/search-results.component';
+import { PropertiesToolbarComponent } from './view/properties-view/properties-toolbar/properties-toolbar.component';
 
 
 
@@ -121,7 +122,8 @@ import { SearchResultsComponent } from './view/search-results/search-results.com
         CompareViewComponent,
         GraphViewComponent,
         PropertiesViewComponent,
-        SearchResultsComponent
+        SearchResultsComponent,
+        PropertiesToolbarComponent
     ],
     exports: [
 


### PR DESCRIPTION
This PR handles the new ReadResource object from @knora/api in the resource viewer including properties view. It's a simple implementation and I use the `strval` only to display property values. We have to reactivate the different property elements depending on value classes later again. (Waiting for the new gui elements where @tobiasschweizer is working on.)

A feature is the new toolbar (not yet fully implemented) on top of property values closes [dasch-swiss/knora-app#91](https://github.com/dasch-swiss/knora-app/issues/91) and deletes branch [dasch-swiss/knora-ui/tree/wip/viewer-resource-toolbar](https://github.com/dasch-swiss/knora-ui/tree/wip/viewer-resource-toolbar)