### PR TITLE
Fix missing delimiter in createOntology

### DIFF
--- a/projects/knora/core/src/lib/services/v2/ontology.service.ts
+++ b/projects/knora/core/src/lib/services/v2/ontology.service.ts
@@ -135,7 +135,7 @@ export class OntologyService extends ApiService {
             },
             'rdfs:label': data.label,
             '@context': {
-                'rdfs': Constants.Rdfs,
+                'rdfs': Constants.Rdfs + Constants.Delimiter,
                 'knora-api': Constants.KnoraApiV2 + Constants.Delimiter
             }
         };


### PR DESCRIPTION
The delimiter '#' at the end of rdfs in `@context` was missing and the "create ontology" post failed.  